### PR TITLE
Enable 64-bit mode back

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,4 +5,4 @@ if [ -s "$HOME/.dvm/scripts/dvm" ] ; then
     dvm use 2.063.2
 fi
 
-rdmd -m32 --build-only -debug -gc -ofbin/dstep -Idstack/mambo -Idstack -L-L. -L-lclang -L-ltango -L-rpath -L. "$@" dstep/driver/DStep.d
+rdmd --build-only -debug -gc -ofbin/dstep -Idstack/mambo -Idstack -L-L. -L-lclang -L-ltango -L-rpath -L. "$@" dstep/driver/DStep.d

--- a/clang/Type.d
+++ b/clang/Type.d
@@ -178,12 +178,12 @@ struct Arguments
 {
 	FuncType type;
 	
-    @property size_t length ()
+    @property uint length ()
     {
 		return clang_getNumArgTypes(type.type.cx);
     }
 
-	Type opIndex (size_t i)
+	Type opIndex (uint i)
 	{
 		auto r = clang_getArgType(type.type.cx, i);
 		return Type(r);


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=5570 has been partially fixed for some time, enough to get dstep running on 64-bit platforms and pass tests.
