### PR TITLE
Removed printing of output to stdout

### DIFF
--- a/dstep/translator/Translator.d
+++ b/dstep/translator/Translator.d
@@ -95,7 +95,6 @@ class Translator
 
 		auto data = output.toString;
 		write(outputFile, data);
-		println(data);
 	}
 	
 	string translate (Cursor cursor, Cursor parent = Cursor.empty)


### PR DESCRIPTION
Having both stdout output and file output at the same time is hardly useful.

This request removes stdout one but I can also do it other way or provide flags for both.
