### PR TITLE
Create support for auto converting includes to imports.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -49,7 +49,7 @@ Use `-h` for usage information. Any flags recognized by Clang can be used.
 ## Limitations/Known issues
 
 * Doesn't translate preprocessor macros of any kind
-* Doesn't translate `#include` to `import`. A few standard C headers are translated
+* Only very simplistic translation of `#include` to `import`. A few standard C headers are translated
 * Doesn't translate C++ at all
 * Umbrella headers. Some headers just serve to include other headers. If these other headers contain some form of protection, like `#error`, to be included directly this can cause problems for DStep
 * Some headers are designed to always be included together with other header files. These headers may very well use symbols from other header files without including them itself. Since DStep is designed to convert header files one-by-one this doesn't work. There are two workarounds for this:

--- a/dstep/driver/Application.d
+++ b/dstep/driver/Application.d
@@ -25,6 +25,7 @@ import clang.Util;
 
 import dstep.core.Exceptions;
 import dstep.translator.Translator;
+import dstep.translator.IncludeHandler;
 
 class Application : DStack.Application
 {
@@ -77,6 +78,14 @@ class Application : DStack.Application
             .on(&handleLanguage);
 
         arguments("objective-c", "Treat source input file as Objective-C input.");
+
+        arguments('f',"import-filter", "A regex to filter includes that will be auto converted.")
+            .params(1)
+            .defaults(".*");
+
+        arguments('p',"import-prefix", "A prefix to add to any custom generated import")
+            .params(1)
+            .defaults("");
     }
 
 private:
@@ -131,6 +140,12 @@ private:
         // FIXME: Cannot use type inference here, probably a bug. Results in segfault.
         if (arguments.rawArgs.any!((string e) => e == "-ObjC"))
             handleObjectiveC();
+
+        if (arguments["import-prefix"].hasValue)
+            handleAutoImportPrefix(arguments["import-prefix"].value);
+
+        if (arguments["import-filter"].hasValue)
+            handleAutoImportFilter(arguments["import-filter"].value);
     }
 
     void handleObjectiveC ()
@@ -166,6 +181,16 @@ private:
 
         argsToRestore ~= "-x";
         argsToRestore ~= language;
+    }
+
+    void handleAutoImportPrefix (string prefix)
+    {
+        includeHandler.autoImportPrefix = prefix;
+    }
+
+    void handleAutoImportFilter (string filter)
+    {
+        includeHandler.autoImportFilter = filter;
     }
 
     @property string[] remainingArgs ()
@@ -213,6 +238,8 @@ private:
         println("    -ObjC, --objective-c         Treat source input file as Objective-C input.");
         println("    -x, --language <language>    Treat subsequent input files as having type <language>.");
         println("    -h, --help                   Show this message and exit.");
+        println("    -f, --import-filter          A regex to filter includes that will be auto converted to imports.");
+        println("    -p, --import-prefix          A prefix to add to any import generated from an include.");
         println();
         println("All options that Clang accepts can be used as well.");
         println();

--- a/features/include_conversion.feature
+++ b/features/include_conversion.feature
@@ -1,0 +1,5 @@
+Feature: Include Conversion
+
+  Scenario: Convert includes
+    Then I test the file "includes" with filter "dummy_includes/transform.*" and prefix "transformed"
+

--- a/features/step_definitions/common.rb
+++ b/features/step_definitions/common.rb
@@ -50,6 +50,13 @@ Then /^I test the file "([^"]*)" in "([^"]*)"$/ do |file, path|
   step %{the files "#{file}.d" and "test_files/#{path}/#{file}.d" should be equal}
 end
 
+Then /^I test the file "([^"]*)" with filter "([^"]*)" and prefix "([^"]*)"$/ do |file, filter, prefix|
+    step %{a test file named "#{file}"}
+    step %{an expected file named "#{file}"}
+    step %{I successfully convert the test file "#{file}" in "" with the flags "--import-filter #{filter} --import-prefix #{prefix}"}
+    step %{the files "#{file}.d" and "test_files/#{file}.d" should be equal}
+end
+
 if OSX
   Then /^I test the Objective\-C file "([^"]*)" in "([^"]*)"$/ do |file, path|
     step %{a test file named "#{file}" in "#{path}"}

--- a/test_files/dummy_includes/README.md
+++ b/test_files/dummy_includes/README.md
@@ -1,0 +1,8 @@
+## Directory dummy_includes
+
+The support for import generation works based on the use of types
+haling from specific includes. That is why to test it
+we need a few dummy includes that define types.
+
+(Other test files cannot be used because they need
+to be free to contain name conflicts.)

--- a/test_files/dummy_includes/ignored.h
+++ b/test_files/dummy_includes/ignored.h
@@ -1,0 +1,1 @@
+struct Ignored{};

--- a/test_files/dummy_includes/transform.h
+++ b/test_files/dummy_includes/transform.h
@@ -1,0 +1,1 @@
+struct Transform{};

--- a/test_files/dummy_includes/transform_also.h
+++ b/test_files/dummy_includes/transform_also.h
@@ -1,0 +1,1 @@
+struct TransformAlso{};

--- a/test_files/includes.d
+++ b/test_files/includes.d
@@ -1,0 +1,5 @@
+import transformed.transform;
+import transformed.transform_also;
+
+extern (C):
+

--- a/test_files/includes.h
+++ b/test_files/includes.h
@@ -1,0 +1,10 @@
+#include "dummy_includes/transform.h"
+#include "dummy_includes/ignored.h"
+#include "dummy_includes/transform_also.h"
+
+// Dstep only pays attention to includes whose types are used so we
+// use a type from each here.
+struct Transform transform;
+struct Ignored ignored;
+struct TransformAlso transform_also;
+


### PR DESCRIPTION
Added command line options
--import-filter
A regular expression. All includes matching this will be converted to imports.
Only the basename part of the file name is used to generate the import.
--import-prefix
A prefix to give the imports. The import will have the form "<prefix><basename>"

This could be extended in the future to support filter-prefix pairs to give different prefixes to
includes from different paths, but this was all I needed for now.
