### PR TITLE
Extend the linker flags to get builds on Debian Sid and Fedora Rawhide.

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -20,7 +20,7 @@
             "targetName": "dstep",
             "sourcePaths": ["dstep", "clang"],
             "importPaths": ["dstep", "clang"],
-            "lflags-posix": ["-lclang", "-rpath", ".", "-L."],
+            "lflags-posix": ["-lclang", "-rpath", ".", "-L.", "-L/usr/lib64/llvm", "-L/usr/lib/llvm-3.7/lib"],
             "lflags-windows": ["+\\", "+clang"]
         },
 


### PR DESCRIPTION
These are the two extra linker flags that allowed builds on Debian Sid and Fedora Rawhide.