### PR TITLE
Translate in order

### DIFF
--- a/clang/Diagnostic.d
+++ b/clang/Diagnostic.d
@@ -6,6 +6,8 @@
  */
 module clang.Diagnostic;
 
+import std.typecons : RefCounted;
+
 import clang.c.Index;
 import clang.Util;
 
@@ -21,5 +23,105 @@ struct Diagnostic
     @property CXDiagnosticSeverity severity ()
     {
         return clang_getDiagnosticSeverity(cx);
+    }
+
+    @property toString()
+    {
+        return format;
+    }
+}
+
+struct DiagnosticSet
+{
+    private struct Container
+    {
+        CXDiagnosticSet set;
+
+        ~this()
+        {
+            if (set != null)
+            {
+                clang_disposeDiagnosticSet(set);
+            }
+        }
+    }
+
+    private RefCounted!Container container;
+    private size_t begin;
+    private size_t end;
+
+    private static RefCounted!Container makeContainer(
+        CXDiagnosticSet set)
+    {
+        RefCounted!Container result;
+        result.set = set;
+        return result;
+    }
+
+    private this(
+        RefCounted!Container container,
+        size_t begin,
+        size_t end)
+    {
+        this.container = container;
+        this.begin = begin;
+        this.end = end;
+    }
+
+    this(CXDiagnosticSet set)
+    {
+        container = makeContainer(set);
+        begin = 0;
+        end = clang_getNumDiagnosticsInSet(container.set);
+    }
+
+    @property bool empty() const
+    {
+        return begin >= end;
+    }
+
+    @property Diagnostic front()
+    {
+        return Diagnostic(clang_getDiagnosticInSet(container.set, cast(uint) begin));
+    }
+
+    @property Diagnostic back()
+    {
+        return Diagnostic(clang_getDiagnosticInSet(container.set, cast(uint) (end - 1)));
+    }
+
+    @property void popFront()
+    {
+        ++begin;
+    }
+
+    @property void popBack()
+    {
+        --end;
+    }
+
+    @property DiagnosticSet save()
+    {
+        return this;
+    }
+
+    @property size_t length() const
+    {
+        return end - begin;
+    }
+
+    Diagnostic opIndex(size_t index)
+    {
+        return Diagnostic(clang_getDiagnosticInSet(container.set, cast(uint) (begin + index)));
+    }
+
+    DiagnosticSet opSlice(size_t begin, size_t end)
+    {
+        return DiagnosticSet(container, this.begin + begin, this.begin + end);
+    }
+
+    size_t opDollar() const
+    {
+        return length;
     }
 }

--- a/clang/Token.d
+++ b/clang/Token.d
@@ -4,7 +4,7 @@
  * Version: Initial created: Feb 14, 2016
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0)
  */
- 
+
 module clang.Token;
 
 import std.typecons;
@@ -97,7 +97,18 @@ struct TokenRange
         return result;
     }
 
-    this(CXTranslationUnit translationUnit,
+    private this(
+        const RefCounted!(Token.Container) container,
+        size_t begin,
+        size_t end)
+    {
+        this.container = container;
+        this.begin = begin;
+        this.end = end;
+    }
+
+    this(
+        CXTranslationUnit translationUnit,
         CXToken* tokens,
         ulong numTokens)
     {
@@ -144,5 +155,15 @@ struct TokenRange
     Token opIndex(size_t index) const
     {
         return Token(container, begin + index);
+    }
+
+    TokenRange opSlice(size_t begin, size_t end) const
+    {
+        return TokenRange(container, this.begin + begin, this.begin + end);
+    }
+
+    size_t opDollar() const
+    {
+        return length;
     }
 }

--- a/clang/Util.d
+++ b/clang/Util.d
@@ -90,7 +90,7 @@ class NamedTempFileException : object.Exception
     }
 }
 
-File namedTempFile(string prefix, string suffix) 
+File namedTempFile(string prefix, string suffix)
 {
     import std.random;
     import std.file;

--- a/dstep/translator/CodeBlock.d
+++ b/dstep/translator/CodeBlock.d
@@ -1,0 +1,160 @@
+/**
+ * Copyright: Copyright (c) 2016 Wojciech Szęszoł. All rights reserved.
+ * Authors: Wojciech Szęszoł
+ * Version: Initial created: Mar 11, 2016
+ * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0)
+ */
+
+module dstep.translator.CodeBlock;
+
+import std.array;
+import std.string;
+
+enum EndlHint
+{
+    /// Does nothing, useful for cases when the translator doesn't produce any ouput.
+    empty,
+
+    /// Special node for grouping, puts an extra new line after grouped items, should not have spelling.
+    group,
+
+    /// Single line item, should not have children.
+    singleLine,
+
+    /// Multiline item, the children are indented.
+    multiLine,
+
+    /// Puts braces if children takes more than single line, useful e.g for loops.
+    subscopeWeak,
+
+    /// Always puts braces, useful e.g. for classes.
+    subscopeStrong,
+}
+
+struct CodeBlock
+{
+    string spelling;
+    EndlHint endlHint;
+    CodeBlock[] children;
+
+    this(string spelling, EndlHint endlHint, CodeBlock[] children = [])
+    {
+        this.spelling = spelling;
+        this.endlHint = endlHint;
+        this.children = children;
+    }
+
+    this(EndlHint endlHint, CodeBlock[] children = [])
+    {
+        this.spelling = "";
+        this.endlHint = endlHint;
+        this.children = children;
+    }
+
+    this(string spelling)
+    {
+        this.spelling = spelling;
+        this.endlHint = EndlHint.singleLine;
+        this.children = [];
+    }
+
+    this(CodeBlock[] children)
+    {
+        this.spelling = null;
+        this.endlHint = EndlHint.group;
+        this.children = children;
+    }
+}
+
+size_t countLines(in CodeBlock block)
+{
+    // this desires to be implemented in more efficient way
+    return compose(block).count("\n");
+}
+
+size_t countLines(in CodeBlock[] blocks)
+{
+    // this desires to be implemented in more efficient way
+    auto output = appender!string();
+    compose(output, blocks, 0);
+    return output.data.count("\n");
+}
+
+void compose(ref Appender!string output, in CodeBlock[] blocks, size_t indent)
+{
+    bool isSubscope(EndlHint hint)
+    {
+        return hint == EndlHint.subscopeWeak || hint == EndlHint.subscopeStrong;
+    }
+
+    if (!blocks.empty)
+    {
+        compose(output, blocks[0], indent);
+
+        foreach (i; 1 .. blocks.length)
+        {
+            if (isSubscope(blocks[i - 1].endlHint)
+                || (isSubscope(blocks[i].endlHint) && blocks[i - 1].endlHint != EndlHint.empty))
+                output.put("\n");
+
+            compose(output, blocks[i], indent);
+        }
+    }
+}
+
+void compose(ref Appender!string output, in CodeBlock block, size_t indent)
+{
+    immutable string tab = "    ";
+
+    output.put(tab.replicate(indent));
+    output.put(block.spelling);
+
+    final switch (block.endlHint)
+    {
+        case EndlHint.empty:
+            break;
+
+        case EndlHint.group:
+            compose(output, block.children, indent);
+
+            if (!output.data.endsWith("\n\n"))
+                output.put("\n");
+
+            break;
+
+        case EndlHint.singleLine:
+            output.put("\n");
+            break;
+
+        case EndlHint.multiLine:
+            output.put("\n");
+            compose(output, block.children, indent + 1);
+            break;
+
+        case EndlHint.subscopeWeak:
+            if (countLines(block.children) == 1)
+            {
+                output.put("\n");
+                compose(output, block.children, indent + 1);
+                break;
+            }
+
+        case EndlHint.subscopeStrong:
+            output.put("\n");
+            output.put(tab.replicate(indent));
+            output.put("{\n");
+            compose(output, block.children, indent + 1);
+            output.put(tab.replicate(indent));
+            output.put("}\n");
+            break;
+    }
+}
+
+string compose(in CodeBlock block)
+{
+    auto output = appender!string();
+
+    compose(output, block, 0);
+
+    return output.data;
+}

--- a/dstep/translator/Declaration.d
+++ b/dstep/translator/Declaration.d
@@ -10,6 +10,7 @@ import mambo.core._;
 
 import clang.Cursor;
 
+import dstep.translator.CodeBlock;
 import dstep.translator.Translator;
 import dstep.translator.Output;
 
@@ -43,7 +44,7 @@ abstract class Declaration
         this.translator = translator;
     }
 
-    abstract string translate ();
+    abstract CodeBlock translate ();
 
     @property string spelling ()
     {

--- a/dstep/translator/Enum.d
+++ b/dstep/translator/Enum.d
@@ -13,6 +13,7 @@ import clang.Cursor;
 import clang.Visitor;
 import clang.Util;
 
+import dstep.translator.CodeBlock;
 import dstep.translator.Translator;
 import dstep.translator.Declaration;
 import dstep.translator.Output;
@@ -25,43 +26,46 @@ class Enum : Declaration
         super(cursor, parent, translator);
     }
 
-    override string translate ()
+    override CodeBlock translate ()
     {
-        return writeEnum(spelling, (context) {
-            foreach (cursor, parent ; cursor.declarations)
+        import std.format : format;
+
+        CodeBlock result = CodeBlock(
+            "enum %s".format(translateIdentifier(spelling)),
+            EndlHint.subscopeStrong);
+
+
+        foreach (cursor, parent; cursor.declarations)
+        {
+            with (CXCursorKind)
             {
-                with (CXCursorKind)
-                    switch (cursor.kind)
-                    {
-                        case CXCursor_EnumConstantDecl:
-                            output.newContext();
-                            output ~= translateIdentifier(cursor.spelling);
-                            output ~= " = ";
-                            output ~= cursor.enum_.value;
-                            context.instanceVariables ~= output.currentContext.data;
+                switch (cursor.kind)
+                {
+                    case CXCursor_EnumConstantDecl:
+                        result.children ~= translateEnumConstantDecl(cursor);
                         break;
 
-                        default: break;
-                    }
+                    default:
+                        break;
+                }
             }
-        });
+        }
+
+        if (result.children.length != 0)
+            result.children[$-1].spelling = result.children[$-1].spelling[0..$-1];
+
+        return result;
+    }
+
+    CodeBlock translateEnumConstantDecl(Cursor cursor)
+    {
+        import std.format : format;
+        return CodeBlock("%s = %s,".format(cursor.spelling, cursor.enum_.value));
     }
 
     @property override string spelling ()
     {
         auto name = cursor.spelling;
         return name.isPresent ? name : generateAnonymousName(cursor);
-    }
-
-private:
-
-    string writeEnum (string name, void delegate (EnumData context) dg)
-    {
-        auto context = new EnumData;
-        context.name = translateIdentifier(name);
-
-        dg(context);
-
-        return context.data;
     }
 }

--- a/dstep/translator/IncludeHandler.d
+++ b/dstep/translator/IncludeHandler.d
@@ -22,6 +22,11 @@ static this ()
     includeHandler_ = new IncludeHandler;
 }
 
+void resetIncludeHandler()
+{
+    includeHandler_ = new IncludeHandler;
+}
+
 class IncludeHandler
 {
     private string[] rawIncludes;

--- a/dstep/translator/Record.d
+++ b/dstep/translator/Record.d
@@ -6,16 +6,17 @@
  */
 module dstep.translator.Record;
 
-import mambo.core._;
+import std.algorithm.mutation;
 
 import clang.c.Index;
 import clang.Cursor;
 import clang.Visitor;
 import clang.Util;
 
-import dstep.translator.Translator;
+import dstep.translator.CodeBlock;
 import dstep.translator.Declaration;
 import dstep.translator.Output;
+import dstep.translator.Translator;
 import dstep.translator.Type;
 
 class Record (Data) : Declaration
@@ -27,7 +28,7 @@ class Record (Data) : Declaration
         super(cursor, parent, translator);
     }
 
-    override string translate ()
+    override CodeBlock translate ()
     {
         return writeRecord(spelling, (context) {
             foreach (cursor, parent ; cursor.declarations)
@@ -45,7 +46,8 @@ class Record (Data) : Declaration
                                 {
                                     output.newContext();
                                     output.currentContext.indent in {
-                                        context.instanceVariables ~= translator.translate(cursor.type.declaration);
+                                        auto code = translator.translate(cursor.type.declaration);
+                                        context.instanceVariables ~= code;
                                     };
                                 }
 
@@ -65,10 +67,10 @@ class Record (Data) : Declaration
 
 private:
 
-    string writeRecord (string name, void delegate (Data context) dg)
+    CodeBlock writeRecord (string name, void delegate (Data context) dg)
     {
         auto context = new Data;
-        
+
         if (cursor.isDefinition)
             this.recordDefinitions[cursor] = true;
         else

--- a/dstep/translator/objc/ObjcInterface.d
+++ b/dstep/translator/objc/ObjcInterface.d
@@ -14,6 +14,7 @@ import clang.Type;
 import clang.Util;
 import clang.Visitor;
 
+import dstep.translator.CodeBlock;
 import dstep.translator.Translator;
 import dstep.translator.Declaration;
 import dstep.translator.Output;
@@ -26,7 +27,7 @@ class ObjcInterface (Data) : Declaration
         super(cursor, parent, translator);
     }
 
-    override string translate ()
+    override CodeBlock translate ()
     {
         auto cursor = cursor.objc;
 
@@ -58,7 +59,7 @@ class ObjcInterface (Data) : Declaration
 
 private:
 
-    string writeClass (string name, string superClassName, string[] interfaces, void delegate () dg)
+    CodeBlock writeClass (string name, string superClassName, string[] interfaces, void delegate () dg)
     {
         output.currentClass = new Data;
         output.currentClass.name = translateIdentifier(name);
@@ -101,11 +102,7 @@ private:
             writeSelector(method, func.spelling);
             method ~= ';';
 
-            if (classMethod)
-                cls.staticMethods ~= method.data;
-
-            else
-                cls.instanceMethods ~= method.data;
+            cls.members ~= CodeBlock(method.data);
         }
     }
 
@@ -122,9 +119,7 @@ private:
 
     void translateInstanceVariable (Cursor cursor)
     {
-        auto var = output.newContext();
-        translator.variable(cursor, var);
-        output.currentClass.instanceVariables ~= var.data;
+        output.currentClass.instanceVariables ~= translator.variable(cursor);
     }
 
     void translateGetter (Type type, String context, string name, ClassData cls, bool classMethod)
@@ -143,14 +138,7 @@ private:
         writeSelector(context, name);
         context ~= ';';
 
-        auto data = context.data;
-
-        if (classMethod)
-            cls.staticProperties ~= data;
-
-        else
-            cls.properties ~= data;
-
+        cls.members ~= CodeBlock(context.data);
         cls.propertyList.add(name);
     }
 
@@ -180,12 +168,7 @@ private:
 
         auto data = context.data;
 
-        if (classMethod)
-            cls.staticProperties ~= data;
-
-        else
-            cls.properties ~= data;
-
+        cls.members ~= CodeBlock(data);
         cls.propertyList.add(selector);
     }
 

--- a/features/aggregate.feature
+++ b/features/aggregate.feature
@@ -1,0 +1,4 @@
+Feature: Aggregate
+
+  Scenario: Convert different statements
+    Then I test the file "aggregate"

--- a/features/array.feature
+++ b/features/array.feature
@@ -1,4 +1,0 @@
-Feature: Array
-
-  Scenario: Convert array
-    Then I test the file "arrays"

--- a/features/const.feature
+++ b/features/const.feature
@@ -1,4 +1,0 @@
-Feature: Const
-
-  Scenario: Convert const
-    Then I test the file "const"

--- a/features/enum.feature
+++ b/features/enum.feature
@@ -1,4 +1,0 @@
-Feature: Enum
-
-  Scenario: Convert enum
-    Then I test the file "enums"

--- a/features/function.feature
+++ b/features/function.feature
@@ -1,4 +1,0 @@
-Feature: Function
-
-  Scenario: Convert function
-    Then I test the file "functions"

--- a/features/function_pointer.feature
+++ b/features/function_pointer.feature
@@ -1,4 +1,0 @@
-Feature: Function Pointer
-
-  Scenario: Convert function pointer
-    Then I test the file "function_pointers"

--- a/features/include.feature
+++ b/features/include.feature
@@ -1,4 +1,0 @@
-Feature: Include
-
-  Scenario: Convert include
-    Then I test the file "include"

--- a/features/objc/category.feature
+++ b/features/objc/category.feature
@@ -1,4 +1,0 @@
-Feature: Category
-
-  Scenario: Convert categories
-    Then I test the Objective-C file "categories" in "objc"

--- a/features/objc/class.feature
+++ b/features/objc/class.feature
@@ -1,4 +1,0 @@
-Feature: Class
-
-  Scenario: Convert classes
-    Then I test the Objective-C file "classes" in "objc"

--- a/features/objc/primitives.feature
+++ b/features/objc/primitives.feature
@@ -1,4 +1,0 @@
-Feature: Primitives
-
-  Scenario: Convert Objective-C primitives
-    Then I test the Objective-C file "primitives" in "objc"

--- a/features/objc/property.feature
+++ b/features/objc/property.feature
@@ -1,4 +1,0 @@
-Feature: Property
-
-  Scenario: Convert property
-    Then I test the Objective-C file "properties" in "objc"

--- a/features/objc/protocol.feature
+++ b/features/objc/protocol.feature
@@ -1,4 +1,0 @@
-Feature: Protocol
-
-  Scenario: Convert protocols
-    Then I test the Objective-C file "protocols" in "objc"

--- a/features/preprocessor.feature
+++ b/features/preprocessor.feature
@@ -1,4 +1,0 @@
-Feature: Preprocessor
-
-  Scenario: Convert preprocessor
-    Then I test the file "preprocessor"

--- a/features/primitives.feature
+++ b/features/primitives.feature
@@ -1,4 +1,0 @@
-Feature: Primitives
-
-  Scenario: Convert primitives
-    Then I test the file "primitives"

--- a/features/struct.feature
+++ b/features/struct.feature
@@ -1,4 +1,0 @@
-Feature: Struct
-
-  Scenario: Convert struct
-    Then I test the file "structs"

--- a/features/typedef.feature
+++ b/features/typedef.feature
@@ -1,4 +1,0 @@
-Feature: Typedef
-
-  Scenario: Convert typedef
-    Then I test the file "typedef"

--- a/features/typedef_struct.feature
+++ b/features/typedef_struct.feature
@@ -1,4 +1,0 @@
-Feature: Struct with typedef
-
-  Scenario: Convert struct with out of order typedef
-    Then I test the file "typedef_struct"

--- a/features/union.feature
+++ b/features/union.feature
@@ -1,4 +1,0 @@
-Feature: Union
-
-  Scenario: Convert union
-    Then I test the file "unions"

--- a/features/variable.feature
+++ b/features/variable.feature
@@ -1,4 +1,0 @@
-Feature: Variable
-
-  Scenario: Convert variables
-    Then I test the file "variables"

--- a/resources/limits.h
+++ b/resources/limits.h
@@ -1,0 +1,118 @@
+/*===---- limits.h - Standard header for integer sizes --------------------===*\
+ *
+ * Copyright (c) 2009 Chris Lattner
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+\*===----------------------------------------------------------------------===*/
+
+#ifndef __CLANG_LIMITS_H
+#define __CLANG_LIMITS_H
+
+/* The system's limits.h may, in turn, try to #include_next GCC's limits.h.
+   Avert this #include_next madness. */
+#if defined __GNUC__ && !defined _GCC_LIMITS_H_
+#define _GCC_LIMITS_H_
+#endif
+
+/* System headers include a number of constants from POSIX in <limits.h>.
+   Include it if we're hosted. */
+#if __STDC_HOSTED__ && __has_include_next(<limits.h>)
+#include_next <limits.h>
+#endif
+
+/* Many system headers try to "help us out" by defining these.  No really, we
+   know how big each datatype is. */
+#undef  SCHAR_MIN
+#undef  SCHAR_MAX
+#undef  UCHAR_MAX
+#undef  SHRT_MIN
+#undef  SHRT_MAX
+#undef  USHRT_MAX
+#undef  INT_MIN
+#undef  INT_MAX
+#undef  UINT_MAX
+#undef  LONG_MIN
+#undef  LONG_MAX
+#undef  ULONG_MAX
+
+#undef  CHAR_BIT
+#undef  CHAR_MIN
+#undef  CHAR_MAX
+
+/* C90/99 5.2.4.2.1 */
+#define SCHAR_MAX __SCHAR_MAX__
+#define SHRT_MAX  __SHRT_MAX__
+#define INT_MAX   __INT_MAX__
+#define LONG_MAX  __LONG_MAX__
+
+#define SCHAR_MIN (-__SCHAR_MAX__-1)
+#define SHRT_MIN  (-__SHRT_MAX__ -1)
+#define INT_MIN   (-__INT_MAX__  -1)
+#define LONG_MIN  (-__LONG_MAX__ -1L)
+
+#define UCHAR_MAX (__SCHAR_MAX__*2  +1)
+#define USHRT_MAX (__SHRT_MAX__ *2  +1)
+#define UINT_MAX  (__INT_MAX__  *2U +1U)
+#define ULONG_MAX (__LONG_MAX__ *2UL+1UL)
+
+#ifndef MB_LEN_MAX
+#define MB_LEN_MAX 1
+#endif
+
+#define CHAR_BIT  __CHAR_BIT__
+
+#ifdef __CHAR_UNSIGNED__  /* -funsigned-char */
+#define CHAR_MIN 0
+#define CHAR_MAX UCHAR_MAX
+#else
+#define CHAR_MIN SCHAR_MIN
+#define CHAR_MAX __SCHAR_MAX__
+#endif
+
+/* C99 5.2.4.2.1: Added long long.
+   C++11 18.3.3.2: same contents as the Standard C Library header <limits.h>.
+ */
+#if __STDC_VERSION__ >= 199901L || __cplusplus >= 201103L
+
+#undef  LLONG_MIN
+#undef  LLONG_MAX
+#undef  ULLONG_MAX
+
+#define LLONG_MAX  __LONG_LONG_MAX__
+#define LLONG_MIN  (-__LONG_LONG_MAX__-1LL)
+#define ULLONG_MAX (__LONG_LONG_MAX__*2ULL+1ULL)
+#endif
+
+/* LONG_LONG_MIN/LONG_LONG_MAX/ULONG_LONG_MAX are a GNU extension.  It's too bad
+   that we don't have something like #pragma poison that could be used to
+   deprecate a macro - the code should just use LLONG_MAX and friends.
+ */
+#if defined(__GNU_LIBRARY__) ? defined(__USE_GNU) : !defined(__STRICT_ANSI__)
+
+#undef   LONG_LONG_MIN
+#undef   LONG_LONG_MAX
+#undef   ULONG_LONG_MAX
+
+#define LONG_LONG_MAX  __LONG_LONG_MAX__
+#define LONG_LONG_MIN  (-__LONG_LONG_MAX__-1LL)
+#define ULONG_LONG_MAX (__LONG_LONG_MAX__*2ULL+1ULL)
+#endif
+
+#endif /* __CLANG_LIMITS_H */

--- a/resources/readme.md
+++ b/resources/readme.md
@@ -1,3 +1,4 @@
 * float.h - 3.5.0
 * stdarg.h - 3.5.0
 * float.h - 3.5.0
+* limits.h - 3.5.0

--- a/test_files/aggregate.d
+++ b/test_files/aggregate.d
@@ -1,0 +1,21 @@
+extern (C):
+
+int b (int out_);
+
+struct Foo
+{
+    int a;
+}
+
+float foo (Foo x);
+float bar (Foo x);
+extern __gshared int a;
+
+struct Bar
+{
+    int x;
+    int y;
+}
+
+extern __gshared const(char)* q;
+extern __gshared int function (int, int) e;

--- a/test_files/aggregate.h
+++ b/test_files/aggregate.h
@@ -1,0 +1,21 @@
+int b (int out);
+
+struct Foo
+{
+    int a;
+};
+
+float foo(struct Foo x);
+float bar(struct Foo x);
+
+int a;
+
+struct Bar
+{
+	int x;
+	int y;
+};
+
+const char* q;
+
+int (*e) (int a, int b);

--- a/test_files/enums.d
+++ b/test_files/enums.d
@@ -1,10 +1,5 @@
 extern (C):
 
-alias _Anonymous_1 D;
-
-extern __gshared Bar e;
-extern __gshared Foo f;
-
 enum Foo
 {
     a = 1
@@ -17,11 +12,8 @@ enum Bar
     d = 3
 }
 
-enum _Anonymous_1
-{
-    k = 1,
-    l = 2
-}
+extern __gshared Bar e;
+extern __gshared Foo f;
 
 struct A
 {
@@ -29,6 +21,7 @@ struct A
     {
         g = 1
     }
+
     B h;
 }
 
@@ -39,5 +32,14 @@ struct C
         i = 1,
         j = 2
     }
+
     _Anonymous_0 point;
 }
+
+enum _Anonymous_1
+{
+    k = 1,
+    l = 2
+}
+
+alias _Anonymous_1 D;

--- a/test_files/objc/methods.d
+++ b/test_files/objc/methods.d
@@ -4,18 +4,15 @@ extern (Objective-C):
 
 class Foo
 {
+    static void classMethod () @selector("classMethod");
+    void instanceMethod () @selector("instanceMethod");
+    static void initialize () @selector("initialize");
     @property static ObjcObject new_ () @selector("new");
     @property static Class class () @selector("class");
+    @property ObjcObject init () @selector("init");
+    static ObjcObject allocWithZone (NSZone* zone) @selector("allocWithZone:");
+    IMP methodForSelector (SEL aSelector) @selector("methodForSelector:");
     @property static NSInteger version_ () @selector("version");
     @property static void version_ (NSInteger aVersion) @selector("setVersion:");
-
-    @property ObjcObject init () @selector("init");
-
-    static void classMethod () @selector("classMethod");
-    static void initialize () @selector("initialize");
-    static ObjcObject allocWithZone (NSZone* zone) @selector("allocWithZone:");
-
-    void instanceMethod () @selector("instanceMethod");
-    IMP methodForSelector (SEL aSelector) @selector("methodForSelector:");
     ObjcObject performSelector (SEL aSelector, ObjcObject object) @selector("performSelector:withObject:");
 }

--- a/test_files/structs.d
+++ b/test_files/structs.d
@@ -1,10 +1,5 @@
 extern (C):
 
-alias _Anonymous_0 D;
-
-extern __gshared Bar b;
-extern __gshared Foo c;
-
 struct Foo
 {
     int a;
@@ -15,12 +10,16 @@ struct Bar
     int x;
 }
 
+extern __gshared Bar b;
+extern __gshared Foo c;
+
 struct A
 {
     struct B
     {
         int x;
     }
+
     B b;
 }
 
@@ -38,6 +37,8 @@ struct _Anonymous_0
     int x;
     int y;
 }
+
+alias _Anonymous_0 D;
 
 struct E
 {

--- a/test_files/unions.d
+++ b/test_files/unions.d
@@ -1,10 +1,5 @@
 extern (C):
 
-alias _Anonymous_0 D;
-
-extern __gshared Bar b;
-extern __gshared Foo c;
-
 union Foo
 {
     int a;
@@ -15,12 +10,16 @@ union Bar
     int x;
 }
 
+extern __gshared Bar b;
+extern __gshared Foo c;
+
 union A
 {
     union B
     {
         int x;
     }
+
     B b;
 }
 
@@ -38,3 +37,5 @@ union _Anonymous_0
     int x;
     int y;
 }
+
+alias _Anonymous_0 D;

--- a/unit_tests/CodeBlockTests.d
+++ b/unit_tests/CodeBlockTests.d
@@ -1,0 +1,169 @@
+/**
+ * Copyright: Copyright (c) 2016 Wojciech Szęszoł. All rights reserved.
+ * Authors: Wojciech Szęszoł
+ * Version: Initial created: Feb 14, 2016
+ * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0)
+ */
+
+import std.stdio;
+import Common;
+import dstep.translator.CodeBlock;
+
+unittest
+{
+    assertEq("\n", compose(CodeBlock("", EndlHint.group, [])));
+
+    auto declInt = CodeBlock("int a;", EndlHint.singleLine, []);
+    auto declFloat = CodeBlock("float b;", EndlHint.singleLine, []);
+    auto group1 = CodeBlock("", EndlHint.group, [declInt, declFloat]);
+
+    assertEq("int a;\nfloat b;\n\n", compose(group1));
+
+    auto declString = CodeBlock("string s;", EndlHint.singleLine, []);
+    auto declFuncDecl = CodeBlock("void func();", EndlHint.singleLine, []);
+    auto group2 = CodeBlock("", EndlHint.group, [declString, declFuncDecl]);
+    auto group3 = CodeBlock("", EndlHint.group, [group1, group2]);
+    assertEq(q"D
+int a;
+float b;
+
+string s;
+void func();
+
+D", compose(group3));
+
+    auto class1 = CodeBlock("class A", EndlHint.subscopeStrong, [declInt, declFloat, declFuncDecl]);
+    assertEq(q"D
+class A
+{
+    int a;
+    float b;
+    void func();
+}
+D", compose(class1));
+
+    auto class2 = CodeBlock("class B", EndlHint.subscopeStrong, [declString]);
+    auto group4 = CodeBlock([class1, class2]);
+    assertEq(q"D
+class A
+{
+    int a;
+    float b;
+    void func();
+}
+
+class B
+{
+    string s;
+}
+
+D", compose(group4));
+
+    auto func1 = CodeBlock("void func1()", EndlHint.subscopeStrong, [class2, declInt]);
+    auto func2 = CodeBlock("void func2()", EndlHint.subscopeStrong, [class2]);
+    auto class3 = CodeBlock("class C", EndlHint.subscopeStrong, [func1, func2, declString]);
+    auto group5 = CodeBlock([class2, class3]);
+    assertEq(q"D
+class B
+{
+    string s;
+}
+
+class C
+{
+    void func1()
+    {
+        class B
+        {
+            string s;
+        }
+
+        int a;
+    }
+
+    void func2()
+    {
+        class B
+        {
+            string s;
+        }
+    }
+
+    string s;
+}
+
+D", compose(group5));
+}
+
+unittest
+{
+    auto declA = CodeBlock("int a;", EndlHint.singleLine);
+    auto declB = CodeBlock("int b;", EndlHint.singleLine);
+    auto declC = CodeBlock("int c = a + b;", EndlHint.singleLine);
+
+    auto if1 = CodeBlock("if (true)", EndlHint.subscopeWeak, [declA]);
+    auto if2 = CodeBlock("if (true)", EndlHint.subscopeWeak, [declA, declB]);
+    auto if3 = CodeBlock("if (true)", EndlHint.subscopeWeak, [declA, declB, declC]);
+
+    assertEq(q"D
+if (true)
+    int a;
+D", compose(if1));
+
+    assertEq(q"D
+if (true)
+{
+    int a;
+    int b;
+}
+D", compose(if2));
+
+    assertEq(q"D
+if (true)
+{
+    int a;
+    int b;
+    int c = a + b;
+}
+D", compose(if3));
+}
+
+// Test EndlHint.MultiLine.
+unittest
+{
+    auto callA = CodeBlock("foo();", EndlHint.singleLine);
+    auto callB = CodeBlock("bar();", EndlHint.singleLine);
+    auto break_ = CodeBlock("break;", EndlHint.singleLine);
+
+    auto case1 = CodeBlock("case UltimateCase:", EndlHint.multiLine, [callA, callB, break_]);
+
+    assertEq(q"D
+case UltimateCase:
+    foo();
+    bar();
+    break;
+D", compose(case1));
+
+}
+
+// Test EndlHint.SubscopeStrong after EndlHint.SingleLine.
+unittest
+{
+    auto callA = CodeBlock("void foo();", EndlHint.singleLine);
+    auto callB = CodeBlock("void bar();", EndlHint.singleLine);
+    auto class1 = CodeBlock("class A", EndlHint.subscopeStrong, [callB]);
+
+    auto case1 = CodeBlock([callA, callB, class1]);
+
+    assertEq(q"D
+void foo();
+void bar();
+
+class A
+{
+    void bar();
+}
+
+D", compose(case1));
+
+}

--- a/unit_tests/Common.d
+++ b/unit_tests/Common.d
@@ -17,8 +17,9 @@ import std.array;
 
 import clang.c.Index;
 
-import dstep.translator.Translator;
+import dstep.translator.IncludeHandler;
 import dstep.translator.Output;
+import dstep.translator.Translator;
 
 public import clang.Compiler;
 public import clang.Cursor;
@@ -28,36 +29,77 @@ public import clang.Token;
 
 Index index;
 
-static this() 
+static this()
 {
     index = Index(false, false);
 }
 
-TranslationUnit makeTranslationUnit(string c) 
+void assertEq(string expected, string actual, string file = __FILE__, size_t line = __LINE__)
+{
+    import std.format : format;
+
+    if (expected != actual)
+    {
+        string showWhitespaces(string x)
+        {
+            return x.replace(" ", "·").replace("\n", "↵\n");
+        }
+
+        auto templ = "\nExpected:\n%s\nActual:\n%s\n";
+        string message = templ.format(
+            showWhitespaces(expected),
+            showWhitespaces(actual));
+        throw new AssertError(message, file, line);
+    }
+}
+
+TranslationUnit makeTranslationUnit(string c)
 {
     return TranslationUnit.parseString(index, c, [], null, CXTranslationUnit_Flags.CXTranslationUnit_DetailedPreprocessingRecord);
 }
 
-string translate(TranslationUnit translationUnit) 
+string translate(TranslationUnit translationUnit, Language language)
 {
+    anonymousNames = string[Cursor].init;
+    resetIncludeHandler();
     resetOutput();
-    auto translator = new Translator(translationUnit);
+    Translator.Options options;
+    options.language = language;
+    auto translator = new Translator(translationUnit, options);
     return translator.translateToString();
 }
 
-class TranslateAssertError : AssertError 
+class TranslateAssertError : AssertError
 {
-    this (string message, string file, ulong line) 
+    this (string message, string file, ulong line)
     {
         super(message, file, line);
     }
 }
 
-void assertTranslates(string c, string d, string file = __FILE__, size_t line = __LINE__) 
+void assertTranslates(
+    string expected,
+    TranslationUnit unit,
+    bool strict,
+    Language language,
+    string file = __FILE__,
+    size_t line = __LINE__)
 {
     import std.format : format;
+    import std.algorithm : map;
+    import std.string : strip;
 
-    auto translated = translate(makeTranslationUnit(c));
+    auto sep = "----------------";
+
+    if (unit.numDiagnostics != 0)
+    {
+        auto diagnostics = unit.diagnosticSet.map!(a => a.toString());
+        string fmt = "\nCannot compile source code. Errors:\n%s\n %s";
+        string message = fmt.format(sep, diagnostics.join("\n"));
+        throw new TranslateAssertError(message, file, line);
+    }
+
+    auto translated = translate(unit, language);
     auto fmt = q"/
 C code translated to:
 %1$s
@@ -66,10 +108,156 @@ C code translated to:
 Expected D code:
 %1$s
 %3$s
-%1$s/";
+%1$s
+AST dump:
+%4$s/";
 
-    string message = format(fmt, "----------------", translated, d);
+    bool failed = translated != expected;
 
-    if (translated != d) 
+    if (failed && !strict)
+        failed = translated.strip() != expected.strip();
+
+    if (failed)
+    {
+        size_t maxSubmessageLength = 10_000;
+        string astDump = unit.dumpAST(true);
+
+        if (maxSubmessageLength < translated.length)
+            translated = translated[0..maxSubmessageLength] ~ "...";
+
+        if (maxSubmessageLength < astDump.length)
+            astDump = astDump[0..maxSubmessageLength] ~ "...";
+
+        string message = format(fmt, sep, translated, expected, astDump);
         throw new TranslateAssertError(message, file, line);
+    }
+}
+
+void assertTranslates(string c, string d, bool strict = false, string file = __FILE__, size_t line = __LINE__)
+{
+    auto unit = makeTranslationUnit(c);
+    assertTranslates(d, unit, strict, Language.c, file, line);
+}
+
+void assertTranslatesFile(
+    string expectedPath,
+    string objCPath,
+    bool strict,
+    Language language,
+    string[] arguments,
+    string file = __FILE__,
+    size_t line = __LINE__)
+{
+    string readFile(string path)
+    {
+        import std.stdio : File;
+        auto file = File(path, "r");
+        char[] buffer = new char[file.size];
+        return file.rawRead(buffer).idup;
+    }
+
+    auto expected = readFile(expectedPath);
+    auto unit = TranslationUnit.parse(index, objCPath, arguments);
+    assertTranslates(expected, unit, strict, language, file, line);
+}
+
+string findGNUStepIncludePath()
+{
+    import std.file : isDir, exists;
+    import std.format : format;
+
+    string path = "/usr/include/GNUstep";
+
+    if (exists(path) && isDir(path))
+        return "-I%s".format(path);
+    else
+        return null;
+}
+
+string[] findCcIncludePaths()
+{
+    string[] extract(string output)
+    {
+        import std.algorithm.searching;
+        import std.algorithm.iteration;
+        import std.string;
+
+        string start = "#include <...> search starts here:";
+        string stop = "End of search list.";
+        auto paths = output.findSplitAfter(start)[1].findSplitBefore(stop)[0].strip();
+        return paths.empty ? null : map!(a => "-I%s".format(a))(paths.splitLines()).array;
+    }
+
+    import std.process : executeShell;
+    auto result = executeShell("cc -E -v - < /dev/null");
+
+    if (result.status == 0)
+        return extract(result.output);
+    else
+        return null;
+}
+
+void assertTranslatesCFile(
+    string expectedPath,
+    string cPath,
+    bool strict = false,
+    string file = __FILE__,
+    size_t line = __LINE__)
+{
+    string[] arguments = ["-Iresources"];
+
+    assertTranslatesFile(
+        expectedPath,
+        cPath,
+        strict,
+        Language.c,
+        arguments,
+        file,
+        line);
+}
+
+void assertTranslatesObjCFile(
+    string expectedPath,
+    string objCPath,
+    bool strict = false,
+    string file = __FILE__,
+    size_t line = __LINE__)
+{
+    string[] arguments = ["-ObjC", "-Iresources"];
+
+    version (linux)
+    {
+        import std.stdio : stderr;
+        import std.format : format;
+
+        auto gnuStepPath = findGNUStepIncludePath();
+
+        if (gnuStepPath == null)
+        {
+            auto message = "Unable to check the assertion. GNUstep couldn't be found.";
+            stderr.writeln("Warning@%s(%d): %s".format(file, line, message));
+            return;
+        }
+
+        auto ccIncludePaths = findCcIncludePaths();
+
+        if (ccIncludePaths == null)
+        {
+            auto message = "Unable to check the assertion. cc include paths couldn't be found.";
+            stderr.writeln("Warning@%s(%d): %s".format(file, line, message));
+            return;
+        }
+
+        arguments ~= ccIncludePaths;
+        arguments ~= gnuStepPath;
+    }
+
+    assertTranslatesFile(
+        expectedPath,
+        objCPath,
+        strict,
+        Language.objC,
+        arguments,
+        file,
+        line);
 }

--- a/unit_tests/FileTests.d
+++ b/unit_tests/FileTests.d
@@ -1,0 +1,151 @@
+/**
+ * Copyright: Copyright (c) 2016 Wojciech Szęszoł. All rights reserved.
+ * Authors: Wojciech Szęszoł
+ * Version: Initial created: Mar 12, 2016
+ * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0)
+ */
+
+import std.stdio;
+import Common;
+import dstep.translator.CodeBlock;
+import dstep.translator.Translator;
+
+unittest
+{
+    assertTranslatesObjCFile(
+        "test_files/objc/categories.d",
+        "test_files/objc/categories.h");
+}
+
+unittest
+{
+    assertTranslatesObjCFile(
+        "test_files/objc/classes.d",
+        "test_files/objc/classes.h");
+}
+
+unittest
+{
+    assertTranslatesObjCFile(
+        "test_files/objc/methods.d",
+        "test_files/objc/methods.h");
+}
+
+unittest
+{
+    assertTranslatesObjCFile(
+        "test_files/objc/primitives.d",
+        "test_files/objc/primitives.h");
+}
+
+unittest
+{
+    assertTranslatesObjCFile(
+        "test_files/objc/properties.d",
+        "test_files/objc/properties.h");
+}
+
+unittest
+{
+    assertTranslatesObjCFile(
+        "test_files/objc/protocols.d",
+        "test_files/objc/protocols.h");
+}
+
+unittest
+{
+    assertTranslatesCFile(
+        "test_files/aggregate.d",
+        "test_files/aggregate.h");
+}
+
+unittest
+{
+    assertTranslatesCFile(
+        "test_files/arrays.d",
+        "test_files/arrays.h");
+}
+
+unittest
+{
+    assertTranslatesCFile(
+        "test_files/const.d",
+        "test_files/const.h");
+}
+
+unittest
+{
+    assertTranslatesCFile(
+        "test_files/enums.d",
+        "test_files/enums.h");
+}
+
+unittest
+{
+    assertTranslatesCFile(
+        "test_files/function_pointers.d",
+        "test_files/function_pointers.h");
+}
+
+unittest
+{
+    assertTranslatesCFile(
+        "test_files/functions.d",
+        "test_files/functions.h");
+}
+
+unittest
+{
+    assertTranslatesCFile(
+        "test_files/include.d",
+        "test_files/include.h");
+}
+
+unittest
+{
+    assertTranslatesCFile(
+        "test_files/preprocessor.d",
+        "test_files/preprocessor.h");
+}
+
+unittest
+{
+    assertTranslatesCFile(
+        "test_files/primitives.d",
+        "test_files/primitives.h");
+}
+
+unittest
+{
+    assertTranslatesCFile(
+        "test_files/structs.d",
+        "test_files/structs.h");
+}
+
+unittest
+{
+    assertTranslatesCFile(
+        "test_files/typedef.d",
+        "test_files/typedef.h");
+}
+
+unittest
+{
+    assertTranslatesCFile(
+        "test_files/typedef_struct.d",
+        "test_files/typedef_struct.h");
+}
+
+unittest
+{
+    assertTranslatesCFile(
+        "test_files/unions.d",
+        "test_files/unions.h");
+}
+
+unittest
+{
+    assertTranslatesCFile(
+        "test_files/variables.d",
+        "test_files/variables.h");
+}

--- a/unit_tests/UnitTests.d
+++ b/unit_tests/UnitTests.d
@@ -7,24 +7,72 @@
 
 import std.stdio;
 import Common;
+import dstep.translator.CodeBlock;
+import dstep.translator.Translator;
 
 unittest
 {
     assertTranslates(
-        "#define SOME_INTEGER 0", 
+        "#define SOME_INTEGER 0",
         "extern (C):\n\nenum SOME_INTEGER = 0;");
 }
 
 unittest
 {
     assertTranslates(
-        "#define FOO 0\n#define BAR 1\n", 
+        "#define FOO 0\n#define BAR 1\n",
         "extern (C):\n\nenum FOO = 0;\nenum BAR = 1;");
 }
 
 unittest
 {
-	assertTranslates(
-        "#define SOME_STRING \"foobar\"", 
-        "extern (C):\n\nenum SOME_STRING = \"foobar\";");	
+    assertTranslates(
+        "#define SOME_STRING \"foobar\"",
+        "extern (C):\n\nenum SOME_STRING = \"foobar\";");
+}
+
+unittest
+{
+    assertTranslates(
+q"C
+struct A
+{
+    struct B
+    {
+        int x;
+    } b;
+};
+C",
+q"D
+extern (C):
+
+struct A
+{
+    struct B
+    {
+        int x;
+    }
+
+    B b;
+}
+D");
+}
+
+unittest
+{
+    assertTranslates(
+q"C
+float foo(int x);
+float bar(int x);
+
+int a;
+C",
+q"D
+extern (C):
+
+float foo (int x);
+float bar (int x);
+extern __gshared int a;
+D");
+
 }


### PR DESCRIPTION
Replaces superfluous switch statement from `Translator.translateString`.
Makes translated statements to appear in C order (at least for existing acceptance tests, I believe it needs more test). 