### PR TITLE
Create Proper directory structure when parsing multiple input files.

### DIFF
--- a/dstep/driver/Application.d
+++ b/dstep/driver/Application.d
@@ -51,10 +51,10 @@ class Application : DStack.Application
         {
             auto inputFiles = arguments.argument.input.values[1 .. $];
             string outputDir = null;
-            if (arguments.output != "" && inputFiles.length > 0)
+            if (inputFiles.length > 0)
             {
                 outputDir = arguments.output;
-                if (!exists(outputDir) || !outputDir.isDir)
+                if (arguments.output.any() && !exists(outputDir))
                     mkdirRecurse(outputDir);
             }
             foreach(string fileName; inputFiles)
@@ -188,11 +188,15 @@ private:
             inputFile = fileName;
 
             if (outputDir != null)
-                outputFile = Path.buildPath(outputDir, defaultOutputFilename());
+                outputFile = Path.buildPath(outputDir, defaultOutputFilename(false));
             else if (!createOutputFileName && arguments.output != "")
                 outputFile = arguments.output;
             else
                 outputFile = defaultOutputFilename();
+
+            outputDir = Path.dirName(outputFile);
+            if (!exists(outputDir))
+                mkdirRecurse(outputDir);
         }
 
         void startConversion ()
@@ -230,9 +234,11 @@ private:
 
     private:
 
-        string defaultOutputFilename ()
+        string defaultOutputFilename (bool useBaseName = true)
         {
-            return Path.setExtension(Path.baseName(inputFile), "d");
+            if (useBaseName)
+                return Path.setExtension(Path.baseName(inputFile), "d");
+            return Path.setExtension(inputFile, "d");
         }
 
         void clean ()

--- a/unit_tests/Common.d
+++ b/unit_tests/Common.d
@@ -282,7 +282,7 @@ void assertRunsDStep(
     {
         foreach (Tuple!(string, string) filesPath; filesPaths)
         {
-            outputPaths ~= buildPath(outputDir, baseName(filesPath[0]));
+            outputPaths ~= buildPath(outputDir, filesPath[0]);
         }
     }
 


### PR DESCRIPTION
Now, if multiple files are passed as input then their directory structure is kept intact.
Ex:
``` dstep path1/file1.h path2/file2.h -o outputDir```
will result in 2 files at ```outputDir/path1/file1.d``` and ```outputDir/path2/file2.d```
.
Just removed using ```baseName``` when parsing multiple files.