### PR TITLE
Issue 47

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 ### New/Changed Features
 
 * Support for simple defines (like `#define FOO 1`)
+* Support for translation of preprocessor constants in array sizes.
 * Basic unit tests were added
 * Most of cucumber tests was replaced with D-based tests.
 * Statements are translated in original 'C' order now.

--- a/clang/Cursor.d
+++ b/clang/Cursor.d
@@ -7,6 +7,7 @@
 module clang.Cursor;
 
 import std.array : appender, Appender;
+import std.conv : to;
 
 import mambo.core._;
 
@@ -58,7 +59,7 @@ struct Cursor
         return location.spelling.file;
     }
 
-    @property string path () const 
+    @property string path () const
     {
         return file.name;
     }

--- a/clang/SourceLocation.d
+++ b/clang/SourceLocation.d
@@ -57,13 +57,13 @@ struct SourceLocation
         return format("SourceLocation(file = %s, line = %d, column = %d, offset = %d)", s.file, s.line, s.column, s.offset);
     }
 
-    static bool lexicalLess(in SourceLocation a, in SourceLocation b)
+    bool lexicalLess(in SourceLocation that)
     {
         File fileA, fileB;
         uint offsetA, offsetB;
 
-        clang_getSpellingLocation(a.cx, &fileA.cx, null, null, &offsetA);
-        clang_getSpellingLocation(b.cx, &fileB.cx, null, null, &offsetB);
+        clang_getSpellingLocation(cx, &fileA.cx, null, null, &offsetA);
+        clang_getSpellingLocation(that.cx, &fileB.cx, null, null, &offsetB);
 
         return fileA != fileB ? fileA < fileB : offsetA < offsetB;
     }

--- a/clang/SourceLocation.d
+++ b/clang/SourceLocation.d
@@ -31,6 +31,15 @@ struct SourceLocation
         return spell;
     }
 
+    @property Spelling expansion() const
+    {
+        Spelling spell;
+
+        clang_getExpansionLocation(cx, &spell.file.cx, &spell.line, &spell.column, &spell.offset);
+
+        return spell;
+    }
+
     @property size_t offset() const
     {
         return spelling.offset;
@@ -46,5 +55,16 @@ struct SourceLocation
         import std.format: format;
         auto s = spelling;
         return format("SourceLocation(file = %s, line = %d, column = %d, offset = %d)", s.file, s.line, s.column, s.offset);
+    }
+
+    static bool lexicalLess(in SourceLocation a, in SourceLocation b)
+    {
+        File fileA, fileB;
+        uint offsetA, offsetB;
+
+        clang_getSpellingLocation(a.cx, &fileA.cx, null, null, &offsetA);
+        clang_getSpellingLocation(b.cx, &fileB.cx, null, null, &offsetB);
+
+        return fileA != fileB ? fileA < fileB : offsetA < offsetB;
     }
 }

--- a/clang/Type.d
+++ b/clang/Type.d
@@ -129,6 +129,15 @@ struct Type
     {
         return ArrayType(this);
     }
+
+    @property bool isArray ()
+    {
+        return
+            kind == CXTypeKind.CXType_ConstantArray ||
+            kind == CXTypeKind.CXType_IncompleteArray ||
+            kind == CXTypeKind.CXType_VariableArray ||
+            kind == CXTypeKind.CXType_DependentSizedArray;
+    }
 }
 
 struct FuncType
@@ -158,6 +167,12 @@ struct ArrayType
     Type type;
     alias type this;
 
+    this (Type type)
+    {
+        assert(type.isArray);
+        this.type = type;
+    }
+
     @property Type elementType ()
     {
         auto r = clang_getArrayElementType(cx);
@@ -167,6 +182,20 @@ struct ArrayType
     @property long size ()
     {
         return clang_getArraySize(cx);
+    }
+
+    @property size_t numDimensions ()
+    {
+        size_t result = 1;
+        auto subtype = elementType();
+
+        while (subtype.isArray)
+        {
+            ++result;
+            subtype = subtype.array.elementType();
+        }
+
+        return result;
     }
 }
 

--- a/dstep/translator/Context.d
+++ b/dstep/translator/Context.d
@@ -24,11 +24,6 @@ class Context
     private string[Cursor] anonymousNames;
     private IncludeHandler includeHandler_;
 
-    public this()
-    {
-        includeHandler_ = new IncludeHandler();
-    }
-
     this(TranslationUnit unit)
     {
         this.unit = unit;

--- a/dstep/translator/Context.d
+++ b/dstep/translator/Context.d
@@ -11,16 +11,28 @@ import mambo.core._;
 
 import clang.c.Index;
 import clang.Cursor;
+import clang.TranslationUnit;
 
 import dstep.translator.IncludeHandler;
+import dstep.translator.MacroIndex;
 
 class Context
 {
+    public MacroIndex macroIndex;
+    public TranslationUnit unit;
+
     private string[Cursor] anonymousNames;
     private IncludeHandler includeHandler_;
 
     public this()
     {
+        includeHandler_ = new IncludeHandler();
+    }
+
+    this(TranslationUnit unit)
+    {
+        this.unit = unit;
+        macroIndex = new MacroIndex(unit);
         includeHandler_ = new IncludeHandler();
     }
 

--- a/dstep/translator/MacroIndex.d
+++ b/dstep/translator/MacroIndex.d
@@ -1,0 +1,103 @@
+/**
+ * Copyright: Copyright (c) 2016 Wojciech Szęszoł. All rights reserved.
+ * Authors: Wojciech Szęszoł
+ * Version: Initial created: Mar 08, 2016
+ * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0)
+ */
+
+module dstep.translator.MacroIndex;
+
+import std.container.rbtree;
+
+import clang.c.Index;
+import clang.Cursor;
+import clang.SourceLocation;
+import clang.SourceRange;
+import clang.TranslationUnit;
+
+class InvalidArgumentError : object.Error
+{
+    this (string message, string file = __FILE__, ulong line = __LINE__)
+    {
+        super(message, file, line);
+    }
+}
+
+class MacroIndex
+{
+    private static bool pred(in Cursor a, in Cursor b)
+    {
+        return SourceLocation.lexicalLess(a.location, b.location);
+    }
+
+    private TranslationUnit unit;
+    private alias CursorRedBlackTree = RedBlackTree!(Cursor, (in Cursor a, in Cursor b) => pred(a, b));
+    private CursorRedBlackTree expansions;
+    private Cursor[string] definitions;
+
+    private static string uniqueID(in Cursor cursor)
+    {
+        import std.format : format;
+        return "%s@%s:%d".format(cursor.spelling, cursor.location.path, cursor.location.offset);
+    }
+
+    this(TranslationUnit unit)
+    {
+        import std.stdio;
+
+        this.unit = unit;
+
+        expansions = new CursorRedBlackTree();
+
+        Cursor[string] recent;
+
+        foreach (cursor, parent; unit.cursor.all)
+        {
+            if (cursor.kind == CXCursorKind.CXCursor_MacroExpansion)
+            {
+                expansions.insert(cursor);
+
+                Cursor* def = cursor.spelling in recent;
+
+                if (def !is null)
+                    definitions[uniqueID(cursor)] = *def;
+            }
+            else if (cursor.kind == CXCursorKind.CXCursor_MacroDefinition)
+            {
+                recent[cursor.spelling] = cursor;
+            }
+        }
+    }
+
+    Cursor queryDefinition(in Cursor expansion) const
+    {
+        if (expansion.kind != CXCursorKind.CXCursor_MacroExpansion)
+            throw new InvalidArgumentError("`expansion` is required to be MacroExpansion.");
+
+        return definitions[uniqueID(expansion)];
+    }
+
+    Cursor[] queryExpansion(Cursor cursor) const
+    {
+        import std.array : array;
+
+        SourceRange extent = cursor.extent;
+        Cursor[] result;
+
+        auto equal = expansions.equalRange(cursor);
+        auto greater = expansions.upperBound(cursor);
+
+        if (!equal.empty)
+            result ~= equal.array;
+
+        foreach (itr; greater)
+        {
+            if (itr.file == cursor.file && itr.location.offset < extent.end.offset)
+                result ~= itr;
+            else
+                break;
+        }
+
+        return result;
+    }
+}

--- a/dstep/translator/Output.d
+++ b/dstep/translator/Output.d
@@ -391,7 +391,7 @@ class ClassData : StructData
         auto mangledName = name;
 
         foreach (param ; func.parameters)
-            mangledName ~= "_" ~ translateType(context, param.type);
+            mangledName ~= "_" ~ translateType(context, param);
 
         return mangledName;
     }
@@ -405,8 +405,8 @@ class ClassData : StructData
 
         formattedWrite(
             header,
-            "%s %s", 
-            type, 
+            "%s %s",
+            type,
             name);
 
         if (superclass.any)

--- a/dstep/translator/Translator.d
+++ b/dstep/translator/Translator.d
@@ -55,7 +55,7 @@ class Translator
         language = options.language;
 
         inputFile = translationUnit.file(inputFilename);
-        context = new Context();
+        context = new Context(translationUnit);
     }
 
     void translate ()
@@ -222,7 +222,7 @@ class Translator
         output.singleLine(
                 "%s%s %s;",
                 prefix,
-                translateType(context, cursor.type),
+                translateType(context, cursor),
                 translateIdentifier(cursor.spelling));
     }
 
@@ -230,7 +230,7 @@ class Translator
     {
         output.singleLine(
             "alias %s %s;",
-            translateType(context, cursor.type.canonicalType),
+            translateType(context, cursor, cursor.type.canonicalType),
             cursor.spelling);
     }
 
@@ -269,11 +269,11 @@ void translateFunction (Output output, Context context, FunctionCursor func, str
 
     foreach (param ; func.parameters)
     {
-        auto type = translateType(context, param.type);
+        auto type = translateType(context, param);
         params ~= Parameter(type, param.spelling);
     }
 
-    auto resultType = translateType(context, func.resultType);
+    auto resultType = translateType(context, func, func.resultType);
 
     translateFunction(output, resultType, name, params, func.isVariadic, isStatic ? "static " : "");
 }

--- a/dstep/translator/objc/ObjcInterface.d
+++ b/dstep/translator/objc/ObjcInterface.d
@@ -107,19 +107,19 @@ private:
         name = cls.getMethodName(func, name, false);
 
         if (isGetter(func, name))
-            translateGetter(func.resultType, name, cls, classMethod);
+            translateGetter(func, func.resultType, name, cls, classMethod);
 
         else if (isSetter(func, name))
         {
             auto param = func.parameters.first;
             name = toDSetterName(name);
-            translateSetter(param.type, name, cls, classMethod, param.spelling);
+            translateSetter(param, param.type, name, cls, classMethod, param.spelling);
         }
 
         else
         {
             Output output = new Output();
-            
+
             translateFunction(output, translator.context, func, name, classMethod),
             output.append(" ");
             writeSelector(output, func.spelling);
@@ -134,8 +134,8 @@ private:
         auto cls = currentClass;
         auto name = cls.getMethodName(cursor.func, "", false);
 
-        translateGetter(cursor.type, name, cls, false);
-        translateSetter(cursor.type, name, cls, false);
+        translateGetter(cursor, cursor.type, name, cls, false);
+        translateSetter(cursor, cursor.type, name, cls, false);
     }
 
     void translateInstanceVariable (Cursor cursor)
@@ -145,7 +145,7 @@ private:
         currentClass.instanceVariables ~= output;
     }
 
-    void translateGetter (Type type, string name, ClassData cls, bool classMethod)
+    void translateGetter (Cursor cursor, Type type, string name, ClassData cls, bool classMethod)
     {
         import std.format : format;
 
@@ -156,7 +156,7 @@ private:
         output.singleLine(
             "@property %s%s %s () ",
             classMethod ? "static " : "",
-            translateType(translator.context, type),
+            translateType(translator.context, cursor, type),
             dName);
 
         writeSelector(output, name);
@@ -166,7 +166,7 @@ private:
         cls.propertyList.add(name);
     }
 
-    void translateSetter (Type type, string name, ClassData cls, bool classMethod, string parameterName = "")
+    void translateSetter (Cursor cursor, Type type, string name, ClassData cls, bool classMethod, string parameterName = "")
     {
         import std.format : format;
 
@@ -178,7 +178,7 @@ private:
             "@property %svoid %s (%s",
             classMethod ? "static " : "",
             translateIdentifier(name),
-            translateType(translator.context, type));
+            translateType(translator.context, cursor, type));
 
         if (parameterName.any)
             output.append(" %s", parameterName);

--- a/unit_tests/UnitTests.d
+++ b/unit_tests/UnitTests.d
@@ -75,3 +75,69 @@ extern __gshared int a;
 D");
 
 }
+
+unittest
+{
+    assertTranslates(
+q"C
+
+#define FOO 4
+
+char var[FOO];
+C",
+q"D
+extern (C):
+
+enum FOO = 4;
+extern __gshared char[FOO] var;
+D");
+
+    assertTranslates(
+q"C
+
+#define BAR 128
+
+struct Foo
+{
+    char var[BAR];
+};
+C",
+q"D
+extern (C):
+
+enum BAR = 128;
+
+struct Foo
+{
+    char[BAR] var;
+}
+D");
+
+    assertTranslates(
+q"C
+
+#define FOO 64
+#define BAR 128
+#define BAZ 256
+
+struct Foo
+{
+    char var[BAR][FOO][BAZ];
+    char rav[BAR][BAZ][42];
+};
+C",
+q"D
+extern (C):
+
+enum FOO = 64;
+enum BAR = 128;
+enum BAZ = 256;
+
+struct Foo
+{
+    char[BAZ][FOO][BAR] var;
+    char[42][BAZ][BAR] rav;
+}
+D");
+
+}

--- a/unittest.d
+++ b/unittest.d
@@ -1,4 +1,5 @@
 
-int main() {
-	return 0;
+int main()
+{
+    return 0;
 }


### PR DESCRIPTION
Adds support for macro-definition constants in array sizes. E.g.

    #define FOO = 1
    char a[FOO];

translates (more or less) to

    enum FOO = 1
    char[FOO] a;