### PR TITLE
Fix 46: Generating code that will not compile.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ clangs
 bin/test
 bin/unittest
 .DS_Store
+resources/VERSION

--- a/changelog.md
+++ b/changelog.md
@@ -13,11 +13,14 @@
 * Most of cucumber tests was replaced with D-based tests.
 * Statements are translated in original 'C' order now.
 * Multiple input files can be processed in different threads.
+* Extend a functionality that automatically replaces aliases to basic types with their D equivalents.
+* Add a switch `dont-reduce-aliases` which disables the above functionality.
 
 ### Bugs fixed
 Issue #2: Self alias should be removed bug.
 Issue #29: Don't name anonymous enums.
 Issue #39: Recognize and translate __attribute__((__packed__)).
+Issue #46: Generating code that will not compile.
 Issue #47: Treatment of #define enhancement.
 Issue #50: struct typedef generates recursive alias bug.
 

--- a/clang/Cursor.d
+++ b/clang/Cursor.d
@@ -96,6 +96,11 @@ struct Cursor
         return Type(r);
     }
 
+    @property Type underlyingType() const
+    {
+        return Type(clang_getTypedefDeclUnderlyingType(cx));
+    }
+
     @property bool isDeclaration ()
     {
         return clang_isDeclaration(cx.kind) != 0;
@@ -402,6 +407,12 @@ struct Cursor
         auto result = appender!string();
         dumpAST(result, 0);
         return result.data;
+    }
+
+    @property string toString()
+    {
+        import std.format : format;
+        return format("Cursor(kind = %s, spelling = %s)", kind, spelling);
     }
 }
 

--- a/clang/SourceLocation.d
+++ b/clang/SourceLocation.d
@@ -75,7 +75,7 @@ struct SourceLocation
 
     @property string toString() const
     {
-        import std.format: format;
+        import std.format : format;
         auto s = spelling;
         return format("SourceLocation(file = %s, line = %d, column = %d, offset = %d)", s.file, s.line, s.column, s.offset);
     }

--- a/dstep/Configuration.d
+++ b/dstep/Configuration.d
@@ -35,4 +35,7 @@ struct Configuration
 
     /// use public imports for submodules
     bool publicSubmodules;
+
+    /// disable reduction of primitive type aliases
+    bool dontReduceAliases;
 }

--- a/dstep/driver/Application.d
+++ b/dstep/driver/Application.d
@@ -61,7 +61,7 @@ class Application
         foreach (fileName; config.inputFiles)
         {
             string outputFilename;
-            
+
             if (singleFileInput)
             {
                 if (config.output.length)
@@ -79,7 +79,7 @@ class Application
             if (!exists(outputDir))
                 mkdirRecurse(outputDir);
 
-            auto conversionTask = task!startParsingFile(config, 
+            auto conversionTask = task!startParsingFile(config,
                 fileName, outputFilename);
 
             conversionTask.executeInNewThread();
@@ -117,7 +117,7 @@ private struct ParseFile
     }
 
     this (
-        const Configuration config, 
+        const Configuration config,
         string inputFile,
         string outputFile)
     {
@@ -153,6 +153,7 @@ private struct ParseFile
             options.enableComments = !config.noComments;
             options.packageName = config.packageName;
             options.publicSubmodules = config.publicSubmodules;
+            options.reduceAliases = !config.dontReduceAliases;
 
             auto translator = new Translator(translationUnit, options);
             translator.translate;

--- a/dstep/main.d
+++ b/dstep/main.d
@@ -62,8 +62,8 @@ auto parseCLI (string[] args)
         "objective-c", "Treat source input file as Objective-C input.", &forceObjectiveC,
         "no-comments", "Disable translation of comments.", &config.noComments,
         "public-submodules", "Use public imports for submodules.", &config.publicSubmodules,
-        "package", "Specify package name.", &config.packageName
-    );
+        "package", "Specify package name.", &config.packageName,
+        "dont-reduce-aliases", "Disable reduction of primitive type aliases.", &config.dontReduceAliases);
 
     // remove dstep binary name (args[0])
     args = args[1 .. $];
@@ -91,19 +91,19 @@ auto parseCLI (string[] args)
 unittest
 {
     import std.meta : AliasSeq;
-    
+
     Configuration config;
     GetoptResult getopResult;
 
     AliasSeq!(config, getopResult) = parseCLI(
-        [ "dstep", "-Xpreprocessor", "-lsomething", "-x", "c-header", "file.h" ]); 
+        [ "dstep", "-Xpreprocessor", "-lsomething", "-x", "c-header", "file.h" ]);
     assert(config.language == Language.c);
     assert(config.inputFiles == [ "file.h" ]);
     assert(config.clangParams == [ "-x", "c-header", "-Xpreprocessor", "-lsomething" ]);
     assert(config.output == "");
 
     AliasSeq!(config, getopResult) = parseCLI(
-        [ "dstep", "-ObjC", "file2.h", "--output=folder", "file.h" ]); 
+        [ "dstep", "-ObjC", "file2.h", "--output=folder", "file.h" ]);
     assert(config.language == Language.objC);
     assert(config.inputFiles == [ "file2.h", "file.h" ]);
     assert(config.clangParams == [ "-ObjC" ]);

--- a/dstep/translator/Context.d
+++ b/dstep/translator/Context.d
@@ -34,10 +34,9 @@ class Context
     private Translator translator_ = null;
     private Output globalScope_ = null;
     private Cursor[string] typeNames_;
-
     public MacroDefinition[string] macroDefinitions;
 
-    const Options options;
+    Options options;
 
     public this(TranslationUnit translUnit, Options options, Translator translator = null)
     {
@@ -59,6 +58,7 @@ class Context
 
         globalScope_ = new Output();
         typeNames_ = collectGlobalTypes(translUnit);
+        this.options = options;
     }
 
     public string getAnonymousName (Cursor cursor)

--- a/dstep/translator/IncludeHandler.d
+++ b/dstep/translator/IncludeHandler.d
@@ -42,6 +42,14 @@ class IncludeHandler
             "stdarg" : "core.stdc.stdarg",
             "stddef" : "core.stdc.stddef",
             "stdint" : "core.stdc.stdint",
+            "_int8_t" : "core.stdc.stdint",
+            "_int16_t" : "core.stdc.stdint",
+            "_int32_t" : "core.stdc.stdint",
+            "_int64_t" : "core.stdc.stdint",
+            "_uint8_t" : "core.stdc.stdint",
+            "_uint16_t" : "core.stdc.stdint",
+            "_uint32_t" : "core.stdc.stdint",
+            "_uint64_t" : "core.stdc.stdint",
             "stdio" : "core.stdc.stdio",
             "stdlib" : "core.stdc.stdlib",
             "string" : "core.stdc.string",
@@ -80,6 +88,7 @@ class IncludeHandler
             "sys/socket" : "core.sys.posix.sys.socket",
             "sys/stat" : "core.sys.posix.sys.stat",
             "sys/time" : "core.sys.posix.sys.time",
+            "_time_t" : "core.stdc.time",
             "sys/types" : "core.sys.posix.sys.types",
             "sys/_types" : "core.sys.posix.sys.types",
             "sys/uio" : "core.sys.posix.sys.uio",
@@ -140,26 +149,26 @@ class IncludeHandler
         import std.array : array;
         import std.format : format;
 
-        string[] standard, package_, unhandled;
+        Set!string standard, package_, unhandled;
 
         foreach (entry; includes.byKey)
         {
             if (auto i = isKnownInclude(entry))
-                standard ~= toImport(i);
+                standard.add(toImport(i));
             else if (auto i = isPackageSubmodule(entry))
-                package_ ~= toSubmoduleImport(i);
+                package_.add(toSubmoduleImport(i));
             else
-                unhandled ~= format(`/+ #include "%s" +/`, entry);
+                unhandled.add(format(`/+ #include "%s" +/`, entry));
         }
 
         auto extra = imports.byKey.map!(e => toImport(e)).array;
 
-        importsBlock(output, standard);
-        importsBlock(output, extra);
-        importsBlock(output, package_);
+        importsBlock(output, standard.keys);
+        importsBlock(output, extra.array);
+        importsBlock(output, package_.keys);
 
         if (options.keepUntranslatable)
-            importsBlock(output, unhandled);
+            importsBlock(output, unhandled.keys);
 
         output.finalize();
     }

--- a/dstep/translator/MacroDefinition.d
+++ b/dstep/translator/MacroDefinition.d
@@ -1339,10 +1339,9 @@ bool parseTypedefName(ref TokenRange tokens, ref Type type, Cursor[string] table
     {
         if (auto ptr = (spelling in table))
         {
-            type.kind = CXTypeKind.CXType_Typedef;
-            type.spelling = spelling;
-
+            type = Type.makeTypedef(spelling, ptr.type.canonical);
             tokens = local;
+
             return true;
         }
     }
@@ -1513,6 +1512,7 @@ bool basicSpecifierListToType(ref Type type, Set!string specifiers)
                 return false;
 
             type = Type(CXTypeKind.CXType_LongDouble, "long double");
+
             return true;
         }
 
@@ -1520,6 +1520,7 @@ bool basicSpecifierListToType(ref Type type, Set!string specifiers)
             return false;
 
         type = Type(CXTypeKind.CXType_Double, "double");
+
         return true;
     }
 

--- a/dstep/translator/Options.d
+++ b/dstep/translator/Options.d
@@ -22,6 +22,22 @@ struct Options
     bool enableComments = true;
     bool publicSubmodules = false;
     bool keepUntranslatable = false;
+    bool reduceAliases = true;
+    bool portableWCharT = true;
+
+    string toString() const
+    {
+        import std.format : format;
+
+        return format(
+            "Options(outputFile = %s, language = %s, enableComments = %s, "
+            "reduceAliases = %s, portableWCharT = %s)",
+            outputFile,
+            language,
+            enableComments,
+            reduceAliases,
+            portableWCharT);
+    }
 }
 
 string fullModuleName(string packageName, string path)

--- a/dstep/translator/Translator.d
+++ b/dstep/translator/Translator.d
@@ -239,6 +239,9 @@ class Translator
             break;
         }
 
+        if (context.options.reduceAliases && cursor.type.isAliasReducible)
+            ignoreTypedef = true;
+
         if (!ignoreTypedef)
         {
             output.singleLine(
@@ -259,14 +262,6 @@ class Translator
     void variable (Output output, Cursor cursor, string prefix = "")
     {
         translateVariable(output, context, cursor, prefix);
-    }
-
-    void typedef_ (Output output, Cursor cursor)
-    {
-        output.singleLine(
-            "alias %s %s;",
-            translateType(context, cursor, cursor.type.canonical),
-            cursor.spelling);
     }
 
 private:

--- a/test_files/objc/cgfloat.d
+++ b/test_files/objc/cgfloat.d
@@ -1,0 +1,5 @@
+
+extern (Objective-C):
+
+extern __gshared CGFloat test;
+void bar (CGFloat foo);

--- a/test_files/objc/cgfloat.h
+++ b/test_files/objc/cgfloat.h
@@ -1,0 +1,5 @@
+#import <CoreGraphics/CoreGraphics.h>
+
+CGFloat test;
+void bar(CGFloat foo);
+

--- a/test_files/objc/methods.d
+++ b/test_files/objc/methods.d
@@ -12,5 +12,6 @@ class Foo
     IMP methodForSelector (SEL aSelector) @selector("methodForSelector:");
     @property static NSInteger version_ () @selector("version");
     @property static void version_ (NSInteger aVersion) @selector("setVersion:");
+    @property static NSUInteger NSUIntegerTest () @selector("NSUIntegerTest");
     ObjcObject performSelector (SEL aSelector, ObjcObject object) @selector("performSelector:withObject:");
 }

--- a/test_files/objc/methods.h
+++ b/test_files/objc/methods.h
@@ -16,6 +16,7 @@
 
 + (NSInteger)version;
 + (void)setVersion:(NSInteger)aVersion;
++ (NSUInteger) NSUIntegerTest;
 
 - (id)performSelector:(SEL)aSelector withObject:(id)object;
 

--- a/test_files/objc/primitives.d
+++ b/test_files/objc/primitives.d
@@ -4,3 +4,5 @@ extern __gshared ObjcObject x9;
 extern __gshared Class x10;
 extern __gshared SEL x11;
 extern __gshared bool x12;
+extern __gshared NSUInteger x13;
+extern __gshared NSInteger x14;

--- a/test_files/objc/primitives.h
+++ b/test_files/objc/primitives.h
@@ -4,3 +4,5 @@ id x9;
 Class x10;
 SEL x11;
 BOOL x12;
+NSUInteger x13;
+NSInteger x14;

--- a/unit_tests/Common.d
+++ b/unit_tests/Common.d
@@ -94,7 +94,7 @@ TranslationUnit makeTranslationUnit(string source)
     return TranslationUnit.parseString(
         index,
         source,
-        ["-Wno-missing-declarations"],
+        ["-Wno-missing-declarations", "-Iresources"],
         null,
         CXTranslationUnit_Flags.CXTranslationUnit_DetailedPreprocessingRecord);
 }
@@ -152,7 +152,7 @@ class TranslateAssertError : AssertError
 
 void assertTranslates(
     string expected,
-    TranslationUnit unit,
+    TranslationUnit translUnit,
     Options options,
     bool strict,
     string file = __FILE__,
@@ -163,15 +163,15 @@ void assertTranslates(
 
     auto sep = "----------------";
 
-    if (unit.numDiagnostics != 0)
+    if (translUnit.numDiagnostics != 0)
     {
-        auto diagnostics = unit.diagnosticSet.map!(a => a.toString());
+        auto diagnostics = translUnit.diagnosticSet.map!(a => a.toString());
         string fmt = "\nCannot compile source code. Errors:\n%s\n %s";
         string message = fmt.format(sep, diagnostics.join("\n"));
         throw new TranslateAssertError(message, file, line);
     }
 
-    auto translated = translate(unit, options);
+    auto translated = translate(translUnit, options);
 
     if (!compareString(expected, translated, strict))
     {
@@ -188,7 +188,7 @@ AST dump:
 %4$s/";
 
         size_t maxSubmessageLength = 10_000;
-        string astDump = unit.dumpAST(true);
+        string astDump = translUnit.dumpAST(true);
 
         if (maxSubmessageLength < translated.length)
             translated = translated[0 .. maxSubmessageLength] ~ "...";

--- a/unit_tests/FileTests.d
+++ b/unit_tests/FileTests.d
@@ -14,6 +14,16 @@ unittest
         "test_files/objc/categories.h");
 }
 
+version (OSX)
+{
+    unittest
+    {
+        assertTranslatesObjCFile(
+            "test_files/objc/cgfloat.d",
+            "test_files/objc/cgfloat.h");
+    }
+}
+
 unittest
 {
     assertTranslatesObjCFile(
@@ -136,9 +146,13 @@ unittest
 
 unittest
 {
+    Options options;
+    options.reduceAliases = false;
+
     assertTranslatesCFile(
         "test_files/typedef.d",
-        "test_files/typedef.h");
+        "test_files/typedef.h",
+        options);
 }
 
 unittest

--- a/unit_tests/UnitTests.d
+++ b/unit_tests/UnitTests.d
@@ -398,3 +398,106 @@ extern __gshared int a;
 D", options);
 
 }
+
+// Translate size types as size types.
+unittest
+{
+   assertTranslates(
+q"C
+#include <stddef.h>
+
+size_t foo;
+ptrdiff_t bar;
+C",
+q"D
+extern (C):
+
+extern __gshared size_t foo;
+extern __gshared ptrdiff_t bar;
+D");
+
+}
+
+// Reduce typedefs when underlying type is alias of primitive type.
+unittest
+{
+    Options options;
+    options.reduceAliases = true;
+
+    assertTranslates(
+q"C
+#include <stdint.h>
+
+uint8_t foo;
+uint32_t bar;
+C",
+q"D
+extern (C):
+
+extern __gshared ubyte foo;
+extern __gshared uint bar;
+D", options);
+
+}
+
+// Do not reduce aliases of unknown types.
+unittest
+{
+   Options options;
+   options.reduceAliases = true;
+
+   assertTranslates(
+q"C
+typedef unsigned int Bar;
+Bar foo;
+C",
+q"D
+extern (C):
+
+alias uint Bar;
+extern __gshared Bar foo;
+D", options);
+
+}
+
+// Disable alias reduction.
+unittest
+{
+    Options options;
+    options.reduceAliases = false;
+
+    assertTranslates(
+q"C
+#include <stdint.h>
+
+uint8_t foo;
+uint32_t bar;
+C",
+q"D
+import core.stdc.stdint;
+
+extern (C):
+
+extern __gshared uint8_t foo;
+extern __gshared uint32_t bar;
+
+D", options);
+
+    options.reduceAliases = true;
+
+    assertTranslates(
+q"C
+#include <stdint.h>
+
+uint8_t foo;
+uint32_t bar;
+C",
+q"D
+extern (C):
+
+extern __gshared ubyte foo;
+extern __gshared uint bar;
+
+D", options);
+
+}

--- a/unit_tests/issues/Issue46.d
+++ b/unit_tests/issues/Issue46.d
@@ -1,0 +1,112 @@
+/**
+ * Copyright: Copyright (c) 2016 Wojciech Szęszoł. All rights reserved.
+ * Authors: Wojciech Szęszoł
+ * Version: Initial created: Jun 27, 2016
+ * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0)
+ */
+
+import Common;
+
+import dstep.translator.Options;
+
+// Fix 46: Generating code that will not compile
+unittest
+{
+    Options options;
+    options.reduceAliases = true;
+
+    assertTranslates(
+q"C
+
+typedef unsigned char __u8;
+typedef unsigned int __u32;
+typedef __signed__ long __s64;
+typedef unsigned long __u64;
+
+struct stats_t {
+    __u8 scale;
+    union {
+        __u64 uvalue;
+        __s64 svalue;
+    };
+} __attribute__ ((packed));
+
+
+#define MAX_STATS   4
+
+struct fe_stats_t {
+    __u8 len;
+    struct stats_t stat[MAX_STATS];
+} __attribute__ ((packed));
+
+struct property_t {
+    __u32 cmd;
+    __u32 reserved[3];
+    union {
+        __u32 data;
+        struct fe_stats_t st;
+        struct {
+            __u8 data[32];
+            __u32 len;
+            __u32 reserved1[3];
+            void *reserved2;
+        } buffer;
+    } u;
+    int result;
+} __attribute__ ((packed));
+C",
+q"D
+extern (C):
+
+struct stats_t
+{
+    align (1):
+
+    ubyte scale;
+
+    union
+    {
+        ulong uvalue;
+        long svalue;
+    }
+}
+
+enum MAX_STATS = 4;
+
+struct fe_stats_t
+{
+    align (1):
+
+    ubyte len;
+    stats_t[MAX_STATS] stat;
+}
+
+struct property_t
+{
+    align (1):
+
+    uint cmd;
+    uint[3] reserved;
+
+    union _Anonymous_0
+    {
+        uint data;
+        fe_stats_t st;
+
+        struct _Anonymous_1
+        {
+            ubyte[32] data;
+            uint len;
+            uint[3] reserved1;
+            void* reserved2;
+        }
+
+        _Anonymous_1 buffer;
+    }
+
+    _Anonymous_0 u;
+    int result;
+}
+D", options);
+
+}


### PR DESCRIPTION
Fixes issue 46 (some of problems from the issue were solved by previous PRs).

Add `dont-reduce-aliases` command line switch. Without the switch aliases for basic arithmetic types are not translated and types are directly translated to appropriate basic type e.g.: `uint8_t -> ubyte`. With the switch the aliased named are kept. Some exceptions are made for idiomatic types like `size_t` or `ptrdiff_t`, which are typedefs but have built-in equivalent in D.
