### PR TITLE
Fix #38: Spurious generation of variadic args.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@ Issue #10: Embedded struct not generated.
 Issue #21: wchar_t should be tranlsated to core.stdc.stddef.wchar_t.
 Issue #29: Don't name anonymous enums.
 Issue #30: Single space inserted after function names.
+Issue #38: Spurious generation of variadic args rather than implicit void.
 Issue #39: Recognize and translate __attribute__((__packed__)).
 Issue #46: Generating code that will not compile.
 Issue #47: Treatment of #define enhancement.

--- a/dstep/Configuration.d
+++ b/dstep/Configuration.d
@@ -47,4 +47,7 @@ struct Configuration
 
     /// no space after function name
     bool noSpaceAfterFunctionName;
+
+    /// translate functions with empty argument list as vararg
+    bool zeroParamIsVararg;
 }

--- a/dstep/driver/Application.d
+++ b/dstep/driver/Application.d
@@ -157,6 +157,7 @@ private struct ParseFile
             options.portableWCharT = !config.noPortableWCharT;
             options.singleLineFunctionHeaders = config.singleLineFunctionHeaders;
             options.noSpaceAfterFunctionName = config.noSpaceAfterFunctionName;
+            options.zeroParamIsVararg = config.zeroParamIsVararg;
 
             auto translator = new Translator(translationUnit, options);
             translator.translate;

--- a/dstep/main.d
+++ b/dstep/main.d
@@ -66,7 +66,8 @@ auto parseCLI (string[] args)
         "dont-reduce-aliases", "Disable reduction of primitive type aliases.", &config.dontReduceAliases,
         "no-portable-wchar_t", "Translate wchar_t to wchar or dchar depending on its size.", &config.noPortableWCharT,
         "single-line-function-headers", "Do not break function headers to multiple lines.", &config.singleLineFunctionHeaders,
-        "no-space-after-function-name", "Do not put a space after a function name.", &config.noSpaceAfterFunctionName);
+        "no-space-after-function-name", "Do not put a space after a function name.", &config.noSpaceAfterFunctionName,
+        "zero-param-is-vararg", "Translate functions with empty argument list as variadic functions.", &config.zeroParamIsVararg);
 
     // remove dstep binary name (args[0])
     args = args[1 .. $];

--- a/dstep/translator/Options.d
+++ b/dstep/translator/Options.d
@@ -26,6 +26,7 @@ struct Options
     bool portableWCharT = true;
     bool singleLineFunctionHeaders = false;
     bool noSpaceAfterFunctionName = false;
+    bool zeroParamIsVararg = false;
 
     string toString() const
     {

--- a/dstep/translator/Translator.d
+++ b/dstep/translator/Translator.d
@@ -300,8 +300,28 @@ private:
     }
 }
 
-void translateFunction (Output output, Context context, FunctionCursor func, string name, bool isStatic = false)
+void translateFunction (
+    Output output,
+    Context context,
+    FunctionCursor func,
+    string name,
+    bool isStatic = false)
 {
+    bool isVariadic(Context context, size_t numParams, FunctionCursor func)
+    {
+        if (func.isVariadic)
+        {
+            if (context.options.zeroParamIsVararg)
+                return true;
+            else if (numParams == 0)
+                return false;
+            else
+                return true;
+        }
+
+        return false;
+    }
+
     Parameter[] params;
 
     if (func.type.isValid) // This will be invalid for Objective-C methods
@@ -322,7 +342,7 @@ void translateFunction (Output output, Context context, FunctionCursor func, str
         resultType,
         name,
         params,
-        func.isVariadic,
+        isVariadic(context, params.length, func),
         isStatic ? "static " : "",
         spacer,
         multiline);

--- a/unit_tests/UnitTests.d
+++ b/unit_tests/UnitTests.d
@@ -591,3 +591,29 @@ extern __gshared dchar x;
 D", options);
 
 }
+
+// Test translation of the function with no argument list.
+unittest
+{
+    assertTranslates(q"C
+void foo();
+C",
+q"D
+extern (C):
+
+void foo ();
+D");
+
+    Options options;
+    options.zeroParamIsVararg = true;
+
+    assertTranslates(q"C
+void foo();
+C",
+q"D
+extern (C):
+
+void foo (...);
+D", options);
+
+}

--- a/unit_tests/issues/Issue38.d
+++ b/unit_tests/issues/Issue38.d
@@ -1,0 +1,43 @@
+/**
+ * Copyright: Copyright (c) 2016 Wojciech Szęszoł. All rights reserved.
+ * Authors: Wojciech Szęszoł
+ * Version: Initial created: Jul 29, 2016
+ * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0)
+ */
+
+import dstep.translator.Options;
+
+import Common;
+
+unittest
+{
+    assertTranslates(q"C
+void foo();
+void bar(const char* fmt, ...);
+void baz(void);
+C",
+q"D
+extern (C):
+
+void foo ();
+void bar (const(char)* fmt, ...);
+void baz ();
+D");
+
+    Options options;
+    options.zeroParamIsVararg = true;
+
+    assertTranslates(q"C
+void foo();
+void bar(const char* fmt, ...);
+void baz(void);
+C",
+q"D
+extern (C):
+
+void foo (...);
+void bar (const(char)* fmt, ...);
+void baz ();
+D", options);
+
+}


### PR DESCRIPTION
Fixes issue #38. Makes dstep to translate function with empty parameter list as functions with empty parameter list. Adds a CLI switch to re-enable old behavior. 

Related info:
https://forum.dlang.org/thread/kywnjtmeifsetjchtrwu@forum.dlang.org
http://stackoverflow.com/a/13950800