### PR TITLE
Fix #59 and #28.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@
 Issue #2: Self alias should be removed bug.
 Issue #10: Embedded struct not generated.
 Issue #21: wchar_t should be tranlsated to core.stdc.stddef.wchar_t.
+Issue #28: Crashes if fed nonexistent header.
 Issue #29: Don't name anonymous enums.
 Issue #30: Single space inserted after function names.
 Issue #38: Spurious generation of variadic args rather than implicit void.
@@ -29,6 +30,7 @@ Issue #39: Recognize and translate __attribute__((__packed__)).
 Issue #46: Generating code that will not compile.
 Issue #47: Treatment of #define enhancement.
 Issue #50: struct typedef generates recursive alias bug.
+Issue #59: Shouldn't dstep exit with status code when there is some kind of error?
 Issue #83: New multiline translation.
 
 ## Version 0.2.1

--- a/dstep/main.d
+++ b/dstep/main.d
@@ -12,7 +12,6 @@ import dstep.Configuration;
 import dstep.translator.Options;
 import dstep.core.Exceptions;
 
-
 /**
  *  Processes command-line arguments
  *
@@ -144,7 +143,7 @@ int main (string[] args)
     }
     catch (DStepException e)
     {
-        writeln("An error occurred: ", e);
+        write(e.msg);
         return -1;
     }
     catch (Throwable e)

--- a/test_files/syntax_error.h
+++ b/test_files/syntax_error.h
@@ -1,0 +1,1 @@
+syntax_error.h

--- a/unit_tests/IntegrationTests.d
+++ b/unit_tests/IntegrationTests.d
@@ -5,6 +5,9 @@
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0)
  */
 import Common;
+
+import std.algorithm : canFind;
+import std.process : executeShell;
 import std.typecons;
 
 unittest
@@ -51,4 +54,47 @@ unittest
     assertRunsDStepCFiles(
         [TestFile("test_files/multiThreadTest1.d", "test_files/multiThreadTest1.h"),
          TestFile("test_files/multiThreadTest2.d", "test_files/multiThreadTest2.h")]);
+}
+
+// DStep should exit with non-zero status when an input file doesn't exist.
+unittest
+{
+    auto result = executeShell("./bin/dstep test_files/nonexistent.h");
+
+    assert(result.status != 0);
+    assert(result.output.canFind("nonexistent.h"));
+}
+
+// DStep should exit with non-zero status when one of the input files doesn't exist.
+unittest
+{
+    auto result = executeShell("./bin/dstep test_files/nonexistent.h test_files/existent.h");
+
+    assert(result.status != 0);
+    assert(result.output.canFind("nonexistent.h"));
+}
+
+// DStep should exit with non-zero status when there is a syntax error in the input file.
+unittest
+{
+    auto result = executeShell("./bin/dstep test_files/syntax_error.h");
+
+    assert(result.status != 0);
+    assert(result.output.canFind("syntax_error.h"));
+}
+
+// DStep should exit with zero status when everything is fine.
+unittest
+{
+    auto result = executeShell("./bin/dstep test_files/aggregate.h");
+
+    assert(result.status == 0);
+}
+
+// DStep should exit with zero status when asked for help.
+unittest
+{
+    auto result = executeShell("./bin/dstep --help");
+
+    assert(result.status == 0);
 }


### PR DESCRIPTION
Fix #59: Shouldn't dstep exit with status code when there is some kind of error?
Fix #28: Crashes if fed nonexistent header.