### PR TITLE
Fix #83 and #30.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,10 +21,12 @@ Issue #2: Self alias should be removed bug.
 Issue #10: Embedded struct not generated.
 Issue #21: wchar_t should be tranlsated to core.stdc.stddef.wchar_t.
 Issue #29: Don't name anonymous enums.
+Issue #30: Single space inserted after function names.
 Issue #39: Recognize and translate __attribute__((__packed__)).
 Issue #46: Generating code that will not compile.
 Issue #47: Treatment of #define enhancement.
 Issue #50: struct typedef generates recursive alias bug.
+Issue #83: New multiline translation.
 
 ## Version 0.2.1
 ### New/Changed Features

--- a/dstep/Configuration.d
+++ b/dstep/Configuration.d
@@ -41,4 +41,10 @@ struct Configuration
 
     /// translate wchar_t to wchar or dchar depending on its size
     bool noPortableWCharT;
+
+    /// single line function headers
+    bool singleLineFunctionHeaders;
+
+    /// no space after function name
+    bool noSpaceAfterFunctionName;
 }

--- a/dstep/driver/Application.d
+++ b/dstep/driver/Application.d
@@ -155,6 +155,8 @@ private struct ParseFile
             options.publicSubmodules = config.publicSubmodules;
             options.reduceAliases = !config.dontReduceAliases;
             options.portableWCharT = !config.noPortableWCharT;
+            options.singleLineFunctionHeaders = config.singleLineFunctionHeaders;
+            options.noSpaceAfterFunctionName = config.noSpaceAfterFunctionName;
 
             auto translator = new Translator(translationUnit, options);
             translator.translate;

--- a/dstep/main.d
+++ b/dstep/main.d
@@ -64,7 +64,9 @@ auto parseCLI (string[] args)
         "public-submodules", "Use public imports for submodules.", &config.publicSubmodules,
         "package", "Specify package name.", &config.packageName,
         "dont-reduce-aliases", "Disable reduction of primitive type aliases.", &config.dontReduceAliases,
-        "no-portable-wchar_t", "Translate wchar_t to wchar or dchar depending on its size.", &config.noPortableWCharT);
+        "no-portable-wchar_t", "Translate wchar_t to wchar or dchar depending on its size.", &config.noPortableWCharT,
+        "single-line-function-headers", "Do not break function headers to multiple lines.", &config.singleLineFunctionHeaders,
+        "no-space-after-function-name", "Do not put a space after a function name.", &config.noSpaceAfterFunctionName);
 
     // remove dstep binary name (args[0])
     args = args[1 .. $];

--- a/dstep/translator/Options.d
+++ b/dstep/translator/Options.d
@@ -24,6 +24,8 @@ struct Options
     bool keepUntranslatable = false;
     bool reduceAliases = true;
     bool portableWCharT = true;
+    bool singleLineFunctionHeaders = false;
+    bool noSpaceAfterFunctionName = false;
 
     string toString() const
     {

--- a/dstep/translator/Translator.d
+++ b/dstep/translator/Translator.d
@@ -314,6 +314,8 @@ void translateFunction (Output output, Context context, FunctionCursor func, str
     }
 
     auto resultType = translateType(context, func, func.resultType);
+    auto multiline = func.extent.isMultiline && !context.options.singleLineFunctionHeaders;
+    auto spacer = context.options.noSpaceAfterFunctionName ? "" : " ";
 
     translateFunction(
         output,
@@ -322,7 +324,8 @@ void translateFunction (Output output, Context context, FunctionCursor func, str
         params,
         func.isVariadic,
         isStatic ? "static " : "",
-        func.extent.isMultiline);
+        spacer,
+        multiline);
 }
 
 package struct Parameter
@@ -339,6 +342,7 @@ package void translateFunction (
     Parameter[] parameters,
     bool variadic,
     string prefix = "",
+    string spacer = " ",
     bool multiline = false)
 {
     import std.format : format;
@@ -375,12 +379,12 @@ package void translateFunction (
         params ~= "...";
 
     if (multiline)
-        output.adaptiveLine("%s%s %s (%@,%@)", prefix, result, name) in {
+        output.adaptiveLine("%s%s %s%s(%@,%@)", prefix, result, name, spacer) in {
             foreach (param; params)
                 output.adaptiveLine(param);
         };
     else
-        output.singleLine("%s%s %s (%s)", prefix, result, name, params.join(", "));
+        output.singleLine("%s%s %s%s(%s)", prefix, result, name, spacer, params.join(", "));
 }
 
 void translateVariable (Output output, Context context, Cursor cursor, string prefix = "")

--- a/unit_tests/UnitTests.d
+++ b/unit_tests/UnitTests.d
@@ -274,6 +274,41 @@ D");
 
 }
 
+// Long function declarations shouldn't be broken, if disabled in options.
+unittest
+{
+    Options options;
+    options.singleLineFunctionHeaders = true;
+
+    assertTranslates(q"C
+void very_long_function_declaration(double way_too_long_argument,
+                           double another_long_argument);
+C",
+q"D
+extern (C):
+
+void very_long_function_declaration (double way_too_long_argument, double another_long_argument);
+D", options);
+
+}
+
+// Test not putting a space after a function name.
+unittest
+{
+    Options options;
+    options.noSpaceAfterFunctionName = true;
+
+    assertTranslates(q"C
+void very_long_function_declaration(double way_too_long_argument, double another_long_argument);
+C",
+q"D
+extern (C):
+
+void very_long_function_declaration(double way_too_long_argument, double another_long_argument);
+D", options);
+
+}
+
 // Test translation of nested anonymous structures that have associated fields.
 unittest
 {


### PR DESCRIPTION
Fix #83: New multiline translation.
Fix #30: Single space inserted after function names.

I know that there was a discussion (#30) about adding formatting features to dstep with some negative arguments, but it doesn't cost much to add them, they can save some time for some people and apparently there is a need for them from some users (at least two at the moment).