### PR TITLE
Improve CLI help.

### DIFF
--- a/dstep/Configuration.d
+++ b/dstep/Configuration.d
@@ -18,12 +18,15 @@ struct Configuration
     /// array of file names to translate to D
     string[] inputFiles;
 
+    /// expected programming language of input files
     @("language|x", "Treat subsequent input files as having type <language>.")
     Language language;
 
+    /// show dstep version
     @("version", "Show dstep version.")
     bool dstepVersion;
 
+    /// show libclang version
     @("clang-version", "Show libclang version.")
     bool clangVersion;
 
@@ -33,28 +36,36 @@ struct Configuration
     /// output file name or folder (in case there are many input files)
     string output;
 
+    /// package name
     @("package", "Use <package> as package name.")
     string packageName;
 
-    @("comments", "Translate comments [default: true].")
+    /// enable translation of comments
+    @("comments", "Translate comments [default].")
     bool enableComments = true;
 
-    @("public-submodules", "Use public imports for submodules [default: false].")
+    /// use public imports for submodules
+    @("public-submodules", "Use public imports for submodules [default].")
     bool publicSubmodules = false;
 
-    @("reduce-aliases", "Reduce primitive type aliases [default: true].")
+    /// enable reduction of primitive type aliases
+    @("reduce-aliases", "Reduce primitive type aliases [default].")
     bool reduceAliases = true;
 
-    @("portable-wchar_t", "Translate wchar_t as core.stdc.stddef.wchar_t [default: true].")
+    /// translate to wchar_t to core.stdc.stddef.wchar_t
+    @("portable-wchar_t", "Translate wchar_t as core.stdc.stddef.wchar_t [default].")
     bool portableWCharT = true;
 
-    @("zero-param-is-vararg", "Translate functions with no arguments as variadic functions [default: false].")
+    /// translate functions with empty argument list as vararg
+    @("zero-param-is-vararg", "Translate functions with no arguments as variadic functions [default].")
     bool zeroParamIsVararg = false;
 
-    @("single-line-function-headers", "Break function headers to multiple lines [default: false].")
-    bool singleLineFunctionHeaders = false;
+    /// single line function headers
+    @("single-line-function-signatures", "Keep function signatures in a single line [default].")
+    bool singleLineFunctionSignatures = false;
 
-    @("space-after-function-name", "Put a space after a function name [default: true].")
+    /// space after function name
+    @("space-after-function-name", "Put a space after a function name [default].")
     bool spaceAfterFunctionName = true;
 }
 
@@ -73,8 +84,36 @@ template makeGetOptArgs(alias config)
                 return &__traits(getMember, config, spelling);
             }
 
+            auto formatHelp(alias spelling)(string help)
+            {
+                import std.algorithm : canFind;
+                import std.format : format;
+                import std.string : replace;
+
+
+                Configuration config;
+
+                static if (is(typeof(__traits(getMember, config, spelling)) == bool))
+                {
+                    auto default_ = "[default]";
+
+                    if (help.canFind(default_))
+                        return help.replace(
+                            default_,
+                            format("[default: %s]", __traits(getMember, config, spelling)));
+                    else
+                        return help;
+                }
+                else
+                {
+                    return help;
+                }
+            }
+
             alias expand = AliasSeq!(
-                __traits(getAttributes, __traits(getMember, config, spelling)),
+                __traits(getAttributes, __traits(getMember, config, spelling))[0],
+                formatHelp!spelling(
+                    __traits(getAttributes, __traits(getMember, config, spelling))[1]),
                 ptr);
         }
         else

--- a/dstep/driver/Application.d
+++ b/dstep/driver/Application.d
@@ -179,7 +179,7 @@ private struct ParseFile
             options.reduceAliases = config.reduceAliases;
             options.portableWCharT = config.portableWCharT;
             options.zeroParamIsVararg = config.zeroParamIsVararg;
-            options.singleLineFunctionHeaders = config.singleLineFunctionHeaders;
+            options.singleLineFunctionSignatures = config.singleLineFunctionSignatures;
             options.spaceAfterFunctionName = config.spaceAfterFunctionName;
 
             auto translator = new Translator(translationUnit, options);

--- a/dstep/driver/Application.d
+++ b/dstep/driver/Application.d
@@ -159,10 +159,6 @@ private struct ParseFile
             config.clangParams,
             compiler.extraHeaders);
 
-        // hope that the diagnostics below handle everything
-        // if (!translationUnit.isValid)
-        //     throw new DStepException("An unknown error occurred");
-
         diagnostics = translationUnit.diagnostics;
 
         enforceCompiled();
@@ -177,14 +173,14 @@ private struct ParseFile
             options.inputFile = inputFile.asAbsNormPath;
             options.outputFile = outputFile.asAbsNormPath;
             options.language = config.language;
-            options.enableComments = !config.noComments;
+            options.enableComments = config.enableComments;
             options.packageName = config.packageName;
             options.publicSubmodules = config.publicSubmodules;
-            options.reduceAliases = !config.dontReduceAliases;
-            options.portableWCharT = !config.noPortableWCharT;
-            options.singleLineFunctionHeaders = config.singleLineFunctionHeaders;
-            options.noSpaceAfterFunctionName = config.noSpaceAfterFunctionName;
+            options.reduceAliases = config.reduceAliases;
+            options.portableWCharT = config.portableWCharT;
             options.zeroParamIsVararg = config.zeroParamIsVararg;
+            options.singleLineFunctionHeaders = config.singleLineFunctionHeaders;
+            options.spaceAfterFunctionName = config.spaceAfterFunctionName;
 
             auto translator = new Translator(translationUnit, options);
             translator.translate;

--- a/dstep/main.d
+++ b/dstep/main.d
@@ -78,6 +78,9 @@ auto parseCLI (string[] args)
 
     import std.algorithm : canFind;
 
+    if (forceObjectiveC)
+        config.clangParams ~= "-ObjC";
+
     if (config.clangParams.canFind("-ObjC"))
         config.language = Language.objC;
 
@@ -167,8 +170,8 @@ void showHelp (Configuration config, GetoptResult getoptResult)
 {
     import std.stdio;
     import std.string;
-    import std.algorithm;
     import std.range;
+    import std.algorithm;
 
     struct Entry
     {
@@ -215,18 +218,21 @@ void showHelp (Configuration config, GetoptResult getoptResult)
 
     auto entries = chain(customEntries, generatedEntries);
 
-    auto maxLength = entries.map!(entry => entry.option.length).maxPos.front;
+    auto maxLength = entries.map!(entry => entry.option.length).array.reduce!max;
 
-    writeln("Usage: dstep [options] <input>");
-    writeln("Version: ", strip(config.Version));
-    writeln();
-    writeln("Options:");
+    auto helpString = appender!string();
+
+    helpString.put("Usage: dstep [options] <input>\n");
+    helpString.put(format("Version: %s\n\n", strip(config.Version)));
+    helpString.put("Options:\n");
 
     foreach (entry; entries)
-        writeln(format("    %-*s %s", cast(int) maxLength + 1, entry.option, entry.help));
+        helpString.put(format("    %-*s %s\n", cast(int) maxLength + 1, entry.option, entry.help));
 
-    writeln("");
-    writeln("All options that Clang accepts can be used as well. "
-        "Use the `-h' flag for help. "
-        "To disable boolean options use false, e.g. --comments=false.");
+    helpString.put(
+        "\nTo disable boolean options use false, e.g. --comments=false.\n"
+        "All options that Clang accepts can be used as well.\n"
+        "Use the `-h' flag for help.");
+
+    writeln(helpString.data);
 }

--- a/dstep/main.d
+++ b/dstep/main.d
@@ -56,19 +56,10 @@ auto parseCLI (string[] args)
         args,
         std.getopt.config.passThrough,
         std.getopt.config.caseSensitive,
-        "version", &config.dstepVersion,
-        "clang-version", &config.clangVersion,
-        "output|o", "Write output to", &config.output,
-        "language|x", "Treat subsequent input files as having type <language>.", &parseLanguage,
-        "objective-c", "Treat source input file as Objective-C input.", &forceObjectiveC,
-        "no-comments", "Disable translation of comments.", &config.noComments,
-        "public-submodules", "Use public imports for submodules.", &config.publicSubmodules,
-        "package", "Specify package name.", &config.packageName,
-        "dont-reduce-aliases", "Disable reduction of primitive type aliases.", &config.dontReduceAliases,
-        "no-portable-wchar_t", "Translate wchar_t to wchar or dchar depending on its size.", &config.noPortableWCharT,
-        "single-line-function-headers", "Do not break function headers to multiple lines.", &config.singleLineFunctionHeaders,
-        "no-space-after-function-name", "Do not put a space after a function name.", &config.noSpaceAfterFunctionName,
-        "zero-param-is-vararg", "Translate functions with empty argument list as variadic functions.", &config.zeroParamIsVararg);
+        "output|o", &config.output,
+        "language|x", &parseLanguage,
+        "objective-c", &forceObjectiveC,
+        makeGetOptArgs!config);
 
     // remove dstep binary name (args[0])
     args = args[1 .. $];
@@ -172,23 +163,70 @@ int main (string[] args)
     return 0;
 }
 
-void showHelp (Configuration config, GetoptResult)
+void showHelp (Configuration config, GetoptResult getoptResult)
 {
     import std.stdio;
     import std.string;
+    import std.algorithm;
+    import std.range;
+
+    struct Entry
+    {
+        this(string option, string help)
+        {
+            this.option = option;
+            this.help = help;
+        }
+
+        this(Option option)
+        {
+            if (option.optShort && option.optLong)
+                this.option = format("%s, %s", option.optShort, option.optLong);
+            else if (option.optShort)
+                this.option = option.optShort;
+            else
+                this.option = option.optLong;
+
+            this.help = option.help;
+
+            auto beginning = findSplitBefore(this.help, "<");
+
+            if (!beginning[0].empty)
+            {
+                auto placeholder = findSplitAfter(beginning[1], ">");
+
+                if (!placeholder[0].empty)
+                    this.option ~= format(" %s", placeholder[0]);
+            }
+        }
+
+        string option;
+        string help;
+    }
+
+    auto customEntries = [
+        Entry("-o, --output <file>", "Write output to <file>."),
+        Entry("-o, --output <directory>", "Write all the files to <directory>, in case of multiple input files."),
+        Entry("-ObjC, --objective-c", "Treat source input file as Objective-C input.")];
+
+    auto generatedEntries = getoptResult.options
+        .filter!(option => !option.help.empty)
+        .map!(option => Entry(option));
+
+    auto entries = chain(customEntries, generatedEntries);
+
+    auto maxLength = entries.map!(entry => entry.option.length).maxPos.front;
 
     writeln("Usage: dstep [options] <input>");
     writeln("Version: ", strip(config.Version));
     writeln();
     writeln("Options:");
-    writeln("    -o, --output <file>          Write output to <file>.");
-    writeln("    -o, --output <directory>     Write all the files to <directory>, in case of multiple input files.");
-    writeln("    -ObjC, --objective-c         Treat source input file as Objective-C input.");
-    writeln("    -x, --language <language>    Treat subsequent input files as having type <language>.");
-    writeln("    -h, --help                   Show this message and exit.");
-    writeln("    --no-comments                Disable translation of comments.");
-    writeln();
-    writeln("All options that Clang accepts can be used as well.");
-    writeln();
-    writeln("Use the `-h' flag for help.");
+
+    foreach (entry; entries)
+        writeln(format("    %-*s %s", cast(int) maxLength + 1, entry.option, entry.help));
+
+    writeln("");
+    writeln("All options that Clang accepts can be used as well. "
+        "Use the `-h' flag for help. "
+        "To disable boolean options use false, e.g. --comments=false.");
 }

--- a/dstep/translator/Options.d
+++ b/dstep/translator/Options.d
@@ -25,7 +25,7 @@ struct Options
     bool reduceAliases = true;
     bool portableWCharT = true;
     bool zeroParamIsVararg = false;
-    bool singleLineFunctionHeaders = false;
+    bool singleLineFunctionSignatures = false;
     bool spaceAfterFunctionName = true;
 
     string toString() const

--- a/dstep/translator/Options.d
+++ b/dstep/translator/Options.d
@@ -17,16 +17,16 @@ struct Options
     string[] inputFiles;
     string inputFile;
     string outputFile;
-    string packageName;
     Language language = Language.c;
+    string packageName;
     bool enableComments = true;
     bool publicSubmodules = false;
     bool keepUntranslatable = false;
     bool reduceAliases = true;
     bool portableWCharT = true;
-    bool singleLineFunctionHeaders = false;
-    bool noSpaceAfterFunctionName = false;
     bool zeroParamIsVararg = false;
+    bool singleLineFunctionHeaders = false;
+    bool spaceAfterFunctionName = true;
 
     string toString() const
     {

--- a/dstep/translator/Translator.d
+++ b/dstep/translator/Translator.d
@@ -335,7 +335,7 @@ void translateFunction (
 
     auto resultType = translateType(context, func, func.resultType);
     auto multiline = func.extent.isMultiline && !context.options.singleLineFunctionHeaders;
-    auto spacer = context.options.noSpaceAfterFunctionName ? "" : " ";
+    auto spacer = context.options.spaceAfterFunctionName ? " " : "";
 
     translateFunction(
         output,

--- a/dstep/translator/Translator.d
+++ b/dstep/translator/Translator.d
@@ -334,7 +334,8 @@ void translateFunction (
     }
 
     auto resultType = translateType(context, func, func.resultType);
-    auto multiline = func.extent.isMultiline && !context.options.singleLineFunctionHeaders;
+    auto multiline = func.extent.isMultiline &&
+        !context.options.singleLineFunctionSignatures;
     auto spacer = context.options.spaceAfterFunctionName ? " " : "";
 
     translateFunction(

--- a/unit_tests/Common.d
+++ b/unit_tests/Common.d
@@ -468,6 +468,19 @@ void assertTranslatesFile(
     import clang.Util : asAbsNormPath;
     import std.file : readText;
 
+    version (OptionalGNUStep)
+    {
+        if (options.language == Language.objC)
+        {
+            auto extra = findExtraGNUStepPaths(file, line);
+
+            if (extra.empty)
+                return;
+            else
+                arguments ~= extra;
+        }
+    }
+
     arguments ~= findExtraIncludePaths();
 
     auto expected = readText(expectedPath);
@@ -588,6 +601,20 @@ void assertRunsDStep(
     import std.format : format;
     import clang.Util : namedTempDir;
     import std.file : readText, mkdirRecurse, copy;
+    import std.algorithm : canFind;
+
+    version (OptionalGNUStep)
+    {
+        if (arguments.canFind("-ObjC") || arguments.canFind("--objective-c"))
+        {
+            auto extra = findExtraGNUStepPaths(file, line);
+
+            if (extra.empty)
+                return;
+            else
+                arguments ~= extra;
+        }
+    }
 
     arguments ~= findExtraIncludePaths();
 
@@ -725,16 +752,6 @@ void assertTranslatesObjCFile(
 {
     string[] arguments = ["-ObjC", "-Iresources"];
 
-    version (OptionalGNUStep)
-    {
-        auto extra = findExtraGNUStepPaths(file, line);
-
-        if (extra.empty)
-            return;
-        else
-            arguments ~= extra;
-    }
-
     options.language = Language.objC;
 
     assertTranslatesFile(
@@ -774,16 +791,6 @@ void assertRunsDStepObjCFile(
     size_t line = __LINE__)
 {
     string[] extended = arguments ~ ["-ObjC", "-Iresources"];
-
-    version (OptionalGNUStep)
-    {
-        auto extra = findExtraGNUStepPaths(file, line);
-
-        if (extra.empty)
-            return;
-        else
-            extended ~= extra;
-    }
 
     assertRunsDStep(
         [TestFile(expectedPath, objCPath)],

--- a/unit_tests/IntegrationTests.d
+++ b/unit_tests/IntegrationTests.d
@@ -23,7 +23,7 @@ unittest
     assertRunsDStepCFile(
         "test_files/comments_disabled.d",
         "test_files/comments_disabled.h",
-        ["--no-comments"]);
+        ["--comments=false"]);
 
     assertRunsDStepCFiles([
         TestFile("test_files/module/main0.d", "test_files/module/main0.h"),

--- a/unit_tests/IntegrationTests.d
+++ b/unit_tests/IntegrationTests.d
@@ -98,3 +98,12 @@ unittest
 
     assert(result.status == 0);
 }
+
+// Test `--objective-c` option.
+unittest
+{
+    assertRunsDStep(
+        [TestFile("test_files/objc/primitives.d", "test_files/objc/primitives.h")],
+        ["--objective-c", "-Iresources"],
+        false);
+}

--- a/unit_tests/UnitTests.d
+++ b/unit_tests/UnitTests.d
@@ -278,7 +278,7 @@ D");
 unittest
 {
     Options options;
-    options.singleLineFunctionHeaders = true;
+    options.singleLineFunctionSignatures = true;
 
     assertTranslates(q"C
 void very_long_function_declaration(double way_too_long_argument,

--- a/unit_tests/UnitTests.d
+++ b/unit_tests/UnitTests.d
@@ -296,7 +296,7 @@ D", options);
 unittest
 {
     Options options;
-    options.noSpaceAfterFunctionName = true;
+    options.spaceAfterFunctionName = false;
 
     assertTranslates(q"C
 void very_long_function_declaration(double way_too_long_argument, double another_long_argument);


### PR DESCRIPTION
The old help:

```
Usage: dstep [options] <input>
Version: v0.2.2-105-g583b72d

Options:
    -o, --output <file>          Write output to <file>.
    -o, --output <directory>     Write all the files to <directory>, in case of multiple input files.
    -ObjC, --objective-c         Treat source input file as Objective-C input.
    -x, --language <language>    Treat subsequent input files as having type <language>.
    -h, --help                   Show this message and exit.
    --no-comments                Disable translation of comments.

All options that Clang accepts can be used as well.

Use the `-h' flag for help.
```

a new one:
```
Usage: dstep [options] <input>
Version: v0.2.2-106-g1d08a02

Options:
    -o, --output <file>             Write output to <file>.
    -o, --output <directory>        Write all the files to <directory>, in case of multiple input files.
    -ObjC, --objective-c            Treat source input file as Objective-C input.
    -x, --language <language>       Treat subsequent input files as having type <language>.
    --version                       Show dstep version.
    --clang-version                 Show libclang version.
    --package <package>             Use <package> as package name.
    --comments                      Translate comments [default: true].
    --public-submodules             Use public imports for submodules [default: false].
    --reduce-aliases                Reduce primitive type aliases [default: true].
    --portable-wchar_t              Translate wchar_t as core.stdc.stddef.wchar_t [default: true].
    --zero-param-is-vararg          Translate functions with no arguments as variadic functions [default: false].
    --single-line-function-headers  Break function headers to multiple lines [default: false].
    --space-after-function-name     Put a space after a function name [default: true].
    -h, --help                      This help information.

All options that Clang accepts can be used as well. Use the `-h' flag for help. To disable boolean options use false, e.g. --comments=false.
```