### PR TITLE
Fix dstep behavior when invoked without arguments.

### DIFF
--- a/dstep/main.d
+++ b/dstep/main.d
@@ -126,7 +126,7 @@ int main (string[] args)
     Configuration config = parseResult[0];
     GetoptResult getoptResult = parseResult[1];
 
-    if (getoptResult.helpWanted)
+    if (getoptResult.helpWanted || args.length == 1)
     {
         showHelp(config, getoptResult);
         return 0;

--- a/unit_tests/IntegrationTests.d
+++ b/unit_tests/IntegrationTests.d
@@ -99,6 +99,15 @@ unittest
     assert(result.status == 0);
 }
 
+// DStep should show help when invoked without arguments.
+unittest
+{
+    auto result = executeShell(`"./bin/dstep"`);
+
+    assert(result.status == 0);
+    assert(result.output.canFind("Usage: dstep [options] <input>"));
+}
+
 // Test `--objective-c` option.
 unittest
 {


### PR DESCRIPTION
As in title.