### PR TITLE
Fix #8: Typedef and anonymous structs.

### DIFF
--- a/clang/Cursor.d
+++ b/clang/Cursor.d
@@ -242,7 +242,7 @@ struct Cursor
         return clang_getCursorLanguage(cx);
     }
 
-    equals_t opEquals (const ref Cursor cursor) const
+    equals_t opEquals (in Cursor cursor) const
     {
         return clang_equalCursors(cast(CXCursor) cursor.cx, cast(CXCursor) cx) != 0;
     }

--- a/clang/SourceLocation.d
+++ b/clang/SourceLocation.d
@@ -31,7 +31,12 @@ struct SourceLocation
     {
         Spelling spell;
 
-        clang_getSpellingLocation(cx, &spell.file.cx, &spell.line, &spell.column, &spell.offset);
+        clang_getSpellingLocation(
+            cx,
+            &spell.file.cx,
+            &spell.line,
+            &spell.column,
+            &spell.offset);
 
         return spell;
     }
@@ -40,7 +45,12 @@ struct SourceLocation
     {
         Spelling spell;
 
-        clang_getExpansionLocation(cx, &spell.file.cx, &spell.line, &spell.column, &spell.offset);
+        clang_getExpansionLocation(
+            cx,
+            &spell.file.cx,
+            &spell.line,
+            &spell.column,
+            &spell.offset);
 
         return spell;
     }
@@ -86,18 +96,25 @@ struct SourceLocation
     @property string toString() const
     {
         import std.format : format;
-        auto s = spelling;
-        return format("SourceLocation(file = %s, line = %d, column = %d, offset = %d)", s.file, s.line, s.column, s.offset);
+        auto localSpelling = spelling;
+
+        return format(
+            "SourceLocation(file = %s, line = %d, column = %d, offset = %d)",
+            localSpelling.file,
+            localSpelling.line,
+            localSpelling.column,
+            localSpelling.offset);
     }
 
-    bool lexicalLess(in SourceLocation that)
+    @property string toColonSeparatedString() const
     {
-        File fileA, fileB;
-        uint offsetA, offsetB;
+        import std.format : format;
+        auto localSpelling = spelling;
 
-        clang_getSpellingLocation(cx, &fileA.cx, null, null, &offsetA);
-        clang_getSpellingLocation(that.cx, &fileB.cx, null, null, &offsetB);
-
-        return fileA != fileB ? fileA < fileB : offsetA < offsetB;
+        return format(
+            "%s:%d:%d",
+            localSpelling.file.name,
+            localSpelling.line,
+            localSpelling.column);
     }
 }

--- a/clang/TranslationUnit.d
+++ b/clang/TranslationUnit.d
@@ -260,6 +260,38 @@ struct TranslationUnit
         return relativeLocationAccessorImpl(cursor.all);
     }
 
+    bool delegate (SourceLocation, SourceLocation)
+        relativeLocationLessOp()
+    {
+        auto accessor = relativeLocationAccessor();
+
+        bool lessOp(SourceLocation a, SourceLocation b)
+        {
+            if (a.file == b.file)
+                return a.offset < b.offset;
+            else
+                return accessor(a) < accessor(b);
+        }
+
+        return &lessOp;
+    }
+
+    bool delegate (Cursor, Cursor)
+        relativeCursorLocationLessOp()
+    {
+        auto accessor = relativeLocationAccessor();
+
+        bool lessOp(Cursor a, Cursor b)
+        {
+            if (a.file == b.file)
+                return a.location.offset < b.location.offset;
+            else
+                return accessor(a.location) < accessor(b.location);
+        }
+
+        return &lessOp;
+    }
+
     private struct TokenRange
     {
         CXTranslationUnit cx;

--- a/dstep/driver/Application.d
+++ b/dstep/driver/Application.d
@@ -183,11 +183,12 @@ private struct ParseFile
             options.spaceAfterFunctionName = config.spaceAfterFunctionName;
             options.skipDefinitions = setFromList(config.skipDefinitions);
             options.skipSymbols = setFromList(config.skipSymbols);
+            options.printDiagnostics = config.printDiagnostics;
+            options.collisionAction = config.collisionAction;
 
             auto translator = new Translator(translationUnit, options);
             translator.translate;
         }
-
     }
 
     ~this ()

--- a/dstep/main.d
+++ b/dstep/main.d
@@ -175,7 +175,7 @@ int main (string[] args)
     }
     catch (Throwable e)
     {
-        writeln("An unknown error occurred: ", e);
+        writeln("dstep: an unknown error occurred: ", e);
         throw e;
     }
 
@@ -206,16 +206,16 @@ void showHelp (Configuration config, GetoptResult getoptResult)
             else
                 this.option = option.optLong;
 
-            this.help = option.help;
+            auto pair = findSplitAfter(option.help, "!");
 
-            auto beginning = findSplitBefore(this.help, "<");
-
-            if (!beginning[0].empty)
+            if (!pair[0].empty)
             {
-                auto placeholder = findSplitAfter(beginning[1], ">");
-
-                if (!placeholder[0].empty)
-                    this.option ~= format(" %s", placeholder[0]);
+                this.option ~= pair[0][0 .. $ - 1];
+                this.help = pair[1];
+            }
+            else
+            {
+                this.help = option.help;
             }
         }
 
@@ -246,8 +246,7 @@ void showHelp (Configuration config, GetoptResult getoptResult)
         helpString.put(format("    %-*s %s\n", cast(int) maxLength + 1, entry.option, entry.help));
 
     helpString.put(
-        "\nTo disable boolean options use false, e.g. --comments=false.\n"
-        "All options that Clang accepts can be used as well.\n"
+        "\nAll options that Clang accepts can be used as well.\n"
         "Use the `-h' flag for help.");
 
     writeln(helpString.data);

--- a/dstep/translator/Enum.d
+++ b/dstep/translator/Enum.d
@@ -60,7 +60,7 @@ void translateEnumDef(Output output, Context context, Cursor cursor)
     auto spelling = "enum";
 
     if (!anonymous || variables || !cursor.isGlobal)
-        spelling = "enum " ~ translateIdentifier(context.translateSpelling(cursor));
+        spelling = "enum " ~ translateIdentifier(context.translateTagSpelling(cursor));
 
     output.subscopeStrong(cursor.extent, "%s", spelling) in
     {

--- a/dstep/translator/MacroDefinition.d
+++ b/dstep/translator/MacroDefinition.d
@@ -1401,8 +1401,7 @@ bool parseRecordSpecifier(ref Token[] tokens, ref Type type, Cursor[string] tabl
     {
         if (auto ptr = (keywordType ~ " " ~ spelling in table))
         {
-            type.kind = CXTypeKind.CXType_Record;
-            type.spelling = spelling;
+            type = ptr.type;
             tokens = local;
             return true;
         }
@@ -1420,9 +1419,7 @@ bool parseEnumSpecifier(ref Token[] tokens, ref Type type, Cursor[string] table)
     {
         if (auto ptr = ("enum " ~ spelling in table))
         {
-            type.kind = CXTypeKind.CXType_Enum;
-            type.spelling = spelling;
-
+            type = ptr.type;
             tokens = local;
             return true;
         }

--- a/dstep/translator/Options.d
+++ b/dstep/translator/Options.d
@@ -14,6 +14,13 @@ enum Language
     objC
 }
 
+enum CollisionAction
+{
+    ignore,
+    rename,
+    abort
+}
+
 struct Options
 {
     string[] inputFiles;
@@ -31,6 +38,8 @@ struct Options
     bool spaceAfterFunctionName = true;
     Set!string skipDefinitions;
     Set!string skipSymbols;
+    bool printDiagnostics = true;
+    CollisionAction collisionAction = CollisionAction.rename;
 
     string toString() const
     {

--- a/dstep/translator/Record.d
+++ b/dstep/translator/Record.d
@@ -44,7 +44,7 @@ void translateRecordDef(
 
     import std.format;
 
-    auto spelling = keepUnnamed ? "" : context.translateSpelling(cursor);
+    auto spelling = keepUnnamed ? "" : context.translateTagSpelling(cursor);
     spelling = spelling == "" ? spelling : " " ~ spelling;
     auto type = translateRecordTypeKeyword(cursor);
 
@@ -96,7 +96,7 @@ void translateRecordDef(
 
 void translateRecordDecl(Output output, Context context, Cursor cursor)
 {
-    auto spelling = context.translateSpelling(cursor);
+    auto spelling = context.translateTagSpelling(cursor);
     spelling = spelling == "" ? spelling : " " ~ spelling;
     auto type = translateRecordTypeKeyword(cursor);
     output.singleLine(cursor.extent, "%s%s;", type, spelling);

--- a/dstep/translator/Translator.d
+++ b/dstep/translator/Translator.d
@@ -17,6 +17,7 @@ import clang.TranslationUnit;
 import clang.Type;
 import clang.Util;
 
+import dstep.core.Exceptions;
 import dstep.Configuration;
 
 import dstep.translator.Context;
@@ -32,6 +33,14 @@ import dstep.translator.Record;
 import dstep.translator.Type;
 
 public import dstep.translator.Options;
+
+class TranslationException : DStepException
+{
+    this (string message, string file = __FILE__, size_t line = __LINE__)
+    {
+        super(message, file, line);
+    }
+}
 
 class Translator
 {

--- a/dstep/translator/Type.d
+++ b/dstep/translator/Type.d
@@ -6,6 +6,10 @@
  */
 module dstep.translator.Type;
 
+import std.conv;
+import std.string;
+import std.range;
+
 import clang.c.Index;
 import clang.Cursor;
 import clang.Type;
@@ -14,8 +18,6 @@ import dstep.translator.Context;
 import dstep.translator.IncludeHandler;
 import dstep.translator.Translator;
 import dstep.translator.Output;
-
-import std.conv;
 
 string translateType (Context context, Cursor cursor, bool rewriteIdToObjcObject = true, bool applyConst = true)
 {
@@ -59,14 +61,18 @@ body
 
                 case CXType_Record:
                 case CXType_Enum:
+                    result = context.translateTagSpelling(type.declaration);
+                    handleInclude(context, type);
+                    break;
+
                 case CXType_ObjCInterface:
                     result = type.spelling;
 
-                    if (result.length == 0)
+                    if (result.empty)
                         result = context.getAnonymousName(type.declaration);
 
                     handleInclude(context, type);
-                break;
+                    break;
 
                 case CXType_ConstantArray:
                 case CXType_IncompleteArray:

--- a/test_files/collision.h
+++ b/test_files/collision.h
@@ -1,0 +1,7 @@
+
+struct struct_and_func_share_name
+{
+	int important_field;
+};
+
+void struct_and_func_share_name();

--- a/unit_tests/IntegrationTests.d
+++ b/unit_tests/IntegrationTests.d
@@ -116,3 +116,9 @@ unittest
         ["--objective-c", "-Iresources"],
         false);
 }
+
+// DStep should issue a warning when it detects a name collision.
+unittest
+{
+    assertIssuesWarning("test_files/collision.h");
+}

--- a/unit_tests/issues/Issue8.d
+++ b/unit_tests/issues/Issue8.d
@@ -1,0 +1,82 @@
+/**
+ * Copyright: Copyright (c) 2016 Wojciech Szęszoł. All rights reserved.
+ * Authors: Wojciech Szęszoł
+ * Version: Initial created: Aug 26, 2016
+ * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0)
+ */
+
+import Common;
+
+// Fix 8: Typedef and anonymous structs.
+
+unittest
+{
+    assertTranslates(q"C
+#include <stdint.h>
+
+typedef struct rd_kafka {
+	int dummy;
+} rd_kafka_t;
+
+typedef struct rd_kafka_topic {
+	int dummy;
+} rd_kafka_topic_t;
+
+typedef struct rd_kafka_metadata {
+        int         broker_cnt;     /* Number of brokers in 'brokers' */
+        struct rd_kafka_metadata_broker *brokers;  /* Brokers */
+
+        int         topic_cnt;      /* Number of topics in 'topics' */
+        struct rd_kafka_metadata_topic *topics;    /* Topics */
+
+        int32_t     orig_broker_id; /* Broker originating this metadata */
+        char       *orig_broker_name; /* Name of originating broker */
+} rd_kafka_metadata_t;
+
+rd_kafka_metadata (rd_kafka_t *rk, int all_topics,
+                   rd_kafka_topic_t *only_rkt,
+                   const struct rd_kafka_metadata **metadatap,
+                   int timeout_ms);
+C",
+q"D
+extern (C):
+
+struct rd_kafka
+{
+    int dummy;
+}
+
+alias rd_kafka rd_kafka_t;
+
+struct rd_kafka_topic
+{
+    int dummy;
+}
+
+alias rd_kafka_topic rd_kafka_topic_t;
+
+struct rd_kafka_metadata_
+{
+    int broker_cnt; /* Number of brokers in 'brokers' */
+    struct rd_kafka_metadata_broker;
+    rd_kafka_metadata_broker* brokers; /* Brokers */
+
+    int topic_cnt; /* Number of topics in 'topics' */
+    struct rd_kafka_metadata_topic;
+    rd_kafka_metadata_topic* topics; /* Topics */
+
+    int orig_broker_id; /* Broker originating this metadata */
+    char* orig_broker_name; /* Name of originating broker */
+}
+
+alias rd_kafka_metadata_ rd_kafka_metadata_t;
+
+int rd_kafka_metadata (
+    rd_kafka_t* rk,
+    int all_topics,
+    rd_kafka_topic_t* only_rkt,
+    const(rd_kafka_metadata_*)* metadatap,
+    int timeout_ms);
+D");
+
+}


### PR DESCRIPTION
As in the title.

I think the major issue of the issue (: P) was fixed some time ago, however this PR makes DStep to rename `struct Foo` to `Foo_` if there is already a symbol with the same name in the global namespace.

It cleans up the implementation of `MacroIndex` too.