### PR TITLE
Use basename when output dir is provided

### DIFF
--- a/dstep/driver/Application.d
+++ b/dstep/driver/Application.d
@@ -73,7 +73,7 @@ class Application
             else
             {
                 outputFilename = Path.buildPath(config.output,
-                    defaultOutputFilename(fileName, false));
+                    defaultOutputFilename(fileName));
             }
 
             string outputDir = Path.dirName(outputFilename);


### PR DESCRIPTION
Previously dstep would try to writing to same folder as the input
file if input is provided via absolute paths, essentially ignoring
output directory argument.

Not sure if anything depends on old behaviour, going to check tests :)