### PR TITLE
Sort entry array after generating

### DIFF
--- a/clang/TranslationUnit.d
+++ b/clang/TranslationUnit.d
@@ -234,6 +234,11 @@ struct TranslationUnit
         foreach (uint index, location; locations)
             map[location.path] ~= Entry(index, location);
 
+        import std.algorithm;
+
+        foreach (key, ref value; map)
+            sort(value);
+
         uint findIndex(SourceLocation a)
         {
             auto entries = map[a.path];


### PR DESCRIPTION
Otherwise `assumeSorted` contract will fail on certain inputs. Specifically it was failing during conversion of `libmpdclient` headers:

```
 dstep -I/usr/lib/clang/3.5.2/include/ -o source/c /usr/include/mpd/*
core.exception.AssertError@/usr/include/dlang/dmd/std/range/package.d(7625): Range is not sorted
```