### PR TITLE
Fix extern variable generation for D1 version

### DIFF
--- a/dstep/translator/Translator.d
+++ b/dstep/translator/Translator.d
@@ -217,7 +217,12 @@ class Translator
 
     void translateVarDecl(Output output, Cursor cursor, Cursor parent)
     {
-        variable(output, cursor, "extern __gshared ");
+        version (D1)
+            string storageClass = "extern ";
+        else
+            string storageClass = "extern __gshared ";
+
+        variable(output, cursor, storageClass);
     }
 
     void translateFunctionDecl(Output output, Cursor cursor, Cursor parent)


### PR DESCRIPTION
Trivial regression noticed when testing current dstep master with our code base