### PR TITLE
Add support for configuring static/dynamic linking of libclang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,7 @@ clangs
 *.gch
 bin/test
 bin/unittest
+bin/dstep_configure
 .DS_Store
 resources/VERSION
+linker_flags.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: d
 d:
   - dmd-2.072.2
   - dmd-2.071.2
-  - dmd-2.070.0
 
 before_script: git fetch --unshallow
 script: "dub --config=test"

--- a/README.markdown
+++ b/README.markdown
@@ -26,7 +26,7 @@ The source code is available under the [Boost Software License 1.0](http://www.b
 #### Requirements
 
 * libclang - [http://clang.llvm.org](http://clang.llvm.org) - 3.4 or later that is binary compatible with 3.4
-* DMD - [http://dlang.org/download.html](http://dlang.org/download.html) - 2.070.0 or later
+* DMD - [http://dlang.org/download.html](http://dlang.org/download.html) - 2.071.2 or later
 * Dub [http://code.dlang.org/download](http://code.dlang.org/download)
 
 #### Building
@@ -38,12 +38,21 @@ The source code is available under the [Boost Software License 1.0](http://www.b
 
 3. Run `dub build`
 
+A configuration script will try to automatically locate libclang by looking
+through a couple of default search paths. If libclang is not found in any of the
+default paths, please manually invoke the configuration script and specify the
+path to where libclang is installed using the `--llvm-path` flag.
+
+```
+$ ./configure --llvm-path /usr/lib/llvm-4.0/lib
+```
+
 ### Windows
 
 #### Requirements
 
 * LLVM - [http://llvm.org/releases/download.html](http://llvm.org/releases/download.html) - pre-built binaries for Windows
-* DMD - [http://dlang.org/download.html](http://dlang.org/download.html) - 2.070.0 or later
+* DMD - [http://dlang.org/download.html](http://dlang.org/download.html) - 2.071.0 or later
 * Dub - [http://code.dlang.org/download](http://code.dlang.org/download)
 * Visual Studio - for example Visual Studio Community
 

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 if [ -s "$HOME/.dvm/scripts/dvm" ] ; then
     . "$HOME/.dvm/scripts/dvm" ;
-    dvm use 2.069.2
+    dvm use 2.071.1
 fi
 
 dub build

--- a/configure
+++ b/configure
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# This wrapper script is necessary due to https://github.com/dlang/dub/issues/910
+
+set -e
+
+dub configure.d "$@"

--- a/configure.d
+++ b/configure.d
@@ -1,0 +1,631 @@
+/+ dub.sdl: name "configure" +/
+/**
+ * This file implements a configuration script that will setup the correct flags
+ * to link with libclang.
+ *
+ * The script will try to automatically detect the location of libclang by
+ * searching through a number of preset library search paths for different
+ * platforms.
+ *
+ * If the script fails to find libclang or fails to find the correct version,
+ * this script provides a flag,`--llvm-config`, which can be used by manually
+ * executing this script (`./configure`) and specifying the path to the LLVM
+ * configuration binary, `llvm-config`. The LLVM configuration binary will then
+ * be used to find the location of libclang.
+ *
+ * The result of invoking this configuration script is a file,
+ * `linker_flags.txt`, which will be created. This file contains the necessary
+ * linker flags which will be read by the linker when building DStep.
+ *
+ * This script is only intended to be used on the Posix platforms.
+ */
+module configure;
+
+import std.algorithm;
+import std.array;
+import std.conv;
+import std.exception;
+import std.file;
+import std.format;
+import std.getopt;
+import std.path;
+import std.process;
+import std.range;
+import std.string;
+import std.uni;
+import std.traits;
+
+version (Posix)
+{
+    version (OSX) {}
+    else version (linux) {}
+    else version (FreeBSD) {}
+    else
+        static assert("The current platform is not supported");
+}
+else
+    static assert("This script should only be run on Posix platforms");
+
+/**
+ * The options of the application.
+ *
+ * When parsing the command line arguments, these fields will be set.
+ */
+struct Options
+{
+    /// Print extra information.
+    bool verbose = true;
+
+    /// Indicates if help/usage information was requested.
+    bool help = false;
+
+    /// The specified path to the LLVM/Clang library path.
+    string llvmLibPath;
+
+    /// The specified path to the location of the `ncurses` library.
+    string ncursesLibPath;
+
+    /// Indicates if libclang should be statically or dynamically linked.
+    bool dynamicClang = true;
+}
+
+/// Default configuration and paths.
+struct DefaultConfig
+{
+static:
+
+    version (D_Ddoc)
+    {
+        /// The name of the Clang dynamic library.
+        enum clangLib = "";
+
+        /**
+         * A list of default paths where to look for the LLVM and Clang
+         * libraries.
+         */
+        immutable string[] llvmLibPaths = [];
+
+        /**
+         * A list of default paths where to look for additional libraries.
+         *
+         * Thes are libraries that are not part of LLVM or Clang which are used
+         * when statically linking libclang.
+         */
+        immutable string[] additionalLibPaths = [];
+
+        /**
+         * The name of the Ncurses static library.
+         *
+         * Used when statically linking libclang.
+         */
+        enum ncursesLib = "";
+
+        /**
+         * The name of the C++ standard library.
+         *
+         * Used when statically linking libclang.
+         */
+        enum cppLib = "c++";
+    }
+
+    else version (OSX)
+    {
+        enum clangLib = "libclang.dylib";
+
+        enum standardPaths = [
+            "/usr/local/lib",
+            "/usr/lib"
+        ];
+
+        immutable llvmLibPaths = [
+            "/opt/local/libexec/llvm-4.0/lib", // MacPorts
+            "/usr/local/opt/llvm40/lib", // Homebrew
+            "/opt/local/libexec/llvm-3.9/lib", // MacPorts
+            "/usr/local/opt/llvm39/lib", // Homebrew
+            "/opt/local/libexec/llvm-3.8/lib", // MacPorts
+            "/usr/local/opt/llvm38/lib", // Homebrew
+            "/opt/local/libexec/llvm-3.7/lib", // MacPorts
+            "/usr/local/opt/llvm37/lib" // Homebrew
+        ] ~ standardPaths;
+
+        immutable additionalLibPaths = [
+            "/opt/local/lib"
+        ] ~ standardPaths;
+
+        enum ncursesLib = "libncurses.a";
+        enum cppLib = "c++";
+    }
+
+    else version (linux)
+    {
+        enum clangLib = "libclang.so";
+
+        enum standardPaths = [
+            "/usr/lib",
+            "/usr/local/lib",
+            "/usr/lib/x86_64-linux-gnu" // Debian
+        ];
+
+        immutable llvmLibPaths = [
+            "/usr/lib/llvm-4.0/lib", // Debian
+            "/usr/lib/llvm-3.9/lib", // Debian
+            "/usr/lib/llvm-3.8/lib", // Debian
+            "/usr/lib/llvm-3.7/lib" // Debian
+        ] ~ standardPaths;
+
+        immutable additionalLibPaths = standardPaths;
+
+        enum ncursesLib = "libncurses.a";
+        enum cppLib = "stdc++";
+    }
+
+    else version (FreeBSD)
+    {
+        enum clangLib = "libclang.so";
+
+        enum standardPaths = [
+            "/usr/lib",
+            "/usr/local/lib"
+        ];
+
+        immutable llvmLibPaths = [
+            "/usr/lib/llvm-4.0/lib",
+            "/usr/lib/llvm-3.9/lib",
+            "/usr/lib/llvm-3.8/lib",
+            "/usr/lib/llvm-3.7/lib"
+        ] ~ standardPaths;
+
+        immutable additionalLibPaths = standardPaths;
+
+        enum ncursesLib = "libncurses.a";
+        enum cppLib = "stdc++";
+    }
+
+    else
+        static assert(false, "Unsupported platform");
+
+    /// The name of the LLVM configure binary.
+    enum llvmConfigExecutable = "llvm-config";
+}
+
+/**
+ * This class represents a path to a file, like a library or an executable.
+ *
+ * It's the abstract base class for the `LibraryPath` and `LLVMConfigPath`
+ * subclasses.
+ */
+class Path
+{
+    private
+    {
+        /**
+         * The name of the file this path represents.
+         *
+         * This is a name for the file that is used in error messages.
+         */
+        string name;
+
+        /**
+         * A set of standard paths to which to search for the file this path
+         * represents.
+         */
+        const(string)[] standardPaths;
+
+        /**
+         * The custom path that was specified when invoking this configuration
+         * script, or `null` if no custom path was specified.
+         */
+        string specifiedPath;
+
+        /// The actual file to look for in `standardPaths` and `specifiedPath`.
+        string fileToCheck;
+
+        /// Local cache for the full path to the file.
+        string path_;
+    }
+
+    alias path this;
+
+    /**
+     * Constructs a new instance of this class.
+     *
+     * Params:
+     *  name = the name of the file this path represents
+     *
+     *  standardPaths = a set of standard paths to which to search for the file
+     *      this path represents
+     *
+     *  specifiedPath = the custom path that was specified when invoking this
+     *      configuration script, or `null` if no custom path was specified
+     *
+     *  fileToCheck = the actual file to look for in `standardPaths` and
+     *      `specifiedPath`
+     */
+    this(string name, const(string)[] standardPaths,
+        string specifiedPath, string fileToCheck)
+    {
+        this.name = name;
+        this.standardPaths = standardPaths;
+        this.specifiedPath = specifiedPath;
+        this.fileToCheck = fileToCheck;
+    }
+
+    /**
+     * Returns the full path to the file this path represents as a string.
+     *
+     * If `specifiedPath` is non-empty, `fileToCheck` will be searched for in
+     * `specifiedPath`. Otherwise `fileToCheck` will be searched for in
+     * `standardPaths`.
+     *
+     * Returns: the full path to the file this path represents
+     */
+    string path()
+    {
+        if (path_.ptr)
+            return path_;
+
+        return path_ = specifiedPath.empty ? standardPath : customPath;
+    }
+
+    override string toString()
+    {
+        return path;
+    }
+
+    /**
+     * Returns the full path of `fileToCheck` by searching in `standardPaths`.
+     *
+     * Returns: the full path of `fileToCheck` by searching in `standardPaths`
+     *
+     * Throws: an `Exception` if `fileToCheck` cannot be found in any of the
+     *  paths in `standardPath`
+     */
+    string standardPath()
+    {
+        auto errorMessage = format("Could not find %s in any of the standard " ~
+            "paths for %s: \n%s\nPlease specify a path manually using " ~
+            "'./configure --%s-path=<path>'.",
+            fileToCheck, name, standardPaths.join('\n'), name.toLower
+        );
+
+        auto result = standardPaths.
+            find!(exists).
+            find!(e => e.buildPath(fileToCheck).exists);
+
+        enforce(!result.empty, errorMessage);
+
+        return result.front.absolutePath;
+    }
+
+private:
+
+    /**
+     * Returns the full path of `fileToCheck` by searching in `specifiedPath`
+     * and the `PATH` environment variable.
+     *
+     * If `fileToCheck` cannot be found in `specifiedPath` it will search for
+     * `fileToCheck` in the `PATH` environment variable. If that fails, an
+     * exception is thrown.
+     *
+     * Returns: the full path of `fileToCheck`
+     *
+     * Throws: an `Exception` if `fileToCheck` cannot be found in
+     *  `specifiedPath` or the `PATH` environment variable
+     */
+    string customPath()
+    {
+        auto path = specifiedPath.asAbsolutePath.asNormalizedPath.to!string;
+
+        auto errorMessage = format("The specified library %s in path '%s' " ~
+            "does not exist.", name, path);
+
+        if (path.exists)
+            return path;
+
+        path = searchPath(specifiedPath);
+        enforce(path.exists, errorMessage);
+
+        return path;
+    }
+}
+
+/**
+ * This mixin template contains shared logic to generate the actual
+ * configuration.
+ */
+mixin template BaseConfigurator()
+{
+    private
+    {
+        /// The name of the file where the configuration is written.
+        enum configPath = "linker_flags.txt";
+
+        /// The options that were the result of parsing the command line flags.
+        Options options;
+
+        /// The default configuration.
+        DefaultConfig defaultConfig;
+
+        /// The LLVM/Clang library path.
+        Path llvmLibPath;
+    }
+
+    /**
+     * Initializes the receiver with the given arguments. This method acts as
+     * the shared constructor.
+     *
+     * Params:
+     *  options = the options
+     *  defaultConfig = the default configuration
+     */
+    void initialize(Options options, DefaultConfig defaultConfig)
+    {
+        this.options = options;
+        this.defaultConfig = defaultConfig;
+
+        llvmLibPath = new Path(
+            "llvm",
+            defaultConfig.llvmLibPaths,
+            options.llvmLibPath,
+            defaultConfig.clangLib
+        );
+    }
+
+private:
+
+    /**
+     * Writes given configuration to the config file.
+     *
+     * Params:
+     *  config = the configuration to write, that is, the linker flags
+     */
+    void writeConfig(string config)
+    {
+        write(configPath, config);
+    }
+
+    /// Returns: the configuration, that is, the linker flags.
+    string config()
+    {
+        return flags.join("\n") ~ '\n';
+    }
+}
+
+/**
+ * This struct contains the logic for generating the configuration for static
+ * linking.
+ */
+struct StaticConfigurator
+{
+    mixin BaseConfigurator;
+
+    private
+    {
+        Path llvmLibPath;
+        string llvmLibPath_;
+        Path ncursesLibPath;
+    }
+
+    /**
+     * Constructs a new instance of this struct with the given arguments.
+     *
+     * Params:
+     *  options = the options
+     *  defaultConfig = the default configuration
+     */
+    this(Options options, DefaultConfig defaultConfig)
+    {
+        initialize(options, defaultConfig);
+
+        ncursesLibPath = new Path("ncurses",
+            DefaultConfig.additionalLibPaths,
+            options.ncursesLibPath, DefaultConfig.ncursesLib);
+    }
+
+    /**
+     * Generates the actual configuration.
+     *
+     * This will locate all required libraries, build a set of linker flags and
+     * write the result to the configuration file.
+     */
+    void generateConfig()
+    {
+        enforceLibrariesExist("ncurses", ncursesLibPath,
+            DefaultConfig.ncursesLib);
+
+        writeConfig(config);
+    }
+
+private:
+
+    /// Return: a range of all the necessary linker flags.
+    auto flags()
+    {
+        return cppFlags.chain(ncursesFlags, llvmFlags, libclangFlags);
+    }
+
+    /**
+     * Returns: a range of linker flags necessary to link with the standard C++
+     *  library.
+     */
+    auto cppFlags()
+    {
+        return format("-l%s", DefaultConfig.cppLib).only;
+    }
+
+    /**
+     * Returns: a range of linker flags necessary to link with the ncurses
+     *  library.
+     */
+    auto ncursesFlags()
+    {
+        return ncursesLibPath.buildPath(DefaultConfig.ncursesLib).only;
+    }
+
+    /**
+     * Returns: a range of linker flags necessary to link with the LLVM
+     *  libraries.
+     */
+    auto llvmFlags()
+    {
+        return dirEntries(llvmLibPath, "libLLVM*.a", SpanMode.shallow);
+    }
+
+    /**
+     * Returns: a range of linker flags necessary to link with the Clang
+     *  libraries.
+     */
+    auto libclangFlags()
+    {
+        return dirEntries(llvmLibPath, "libclang*.a", SpanMode.shallow);
+    }
+}
+
+/**
+ * This struct contains the logic for generating the configuration for dynamic
+ * linking.
+ */
+struct DynamicConfigurator
+{
+    mixin BaseConfigurator;
+
+    /**
+     * Constructs a new instance of this struct with the given arguments.
+     *
+     * Params:
+     *  options = the options
+     *  defaultConfig = the default configuration
+     */
+    this(Options options, DefaultConfig defaultConfig)
+    {
+        initialize(options, defaultConfig);
+    }
+
+    /**
+     * Generates the actual configuration.
+     *
+     * This will locate all required libraries, build a set of linker flags and
+     * write the result to the configuration file.
+     */
+    void generateConfig()
+    {
+        enforceLibrariesExist("libclang", llvmLibPath, DefaultConfig.clangLib);
+
+        writeConfig(config);
+    }
+
+private:
+
+    /// Return: a range of all the necessary linker flags.
+    auto flags()
+    {
+        return format("-L%1$s\n-lclang\n-Xlinker -rpath %1$s", llvmLibPath)
+            .only;
+    }
+}
+
+/// The main entry point of this script.
+void main(string[] args)
+{
+    auto options = parseArguments(args);
+
+    if (!options.help)
+    {
+        if (options.dynamicClang)
+            DynamicConfigurator(options, DefaultConfig()).generateConfig();
+        else
+            StaticConfigurator(options, DefaultConfig()).generateConfig();
+    }
+}
+
+private:
+
+/**
+ * Parses the command line arguments given to the application.
+ *
+ * Params:
+ *  args = the command line arguments to parse
+ *
+ * Returns: the options set while parsing the arguments
+ */
+Options parseArguments(string[] args)
+{
+    Options options;
+
+    auto help = getopt(args,
+        "llvm-path", "The path to where the LLVM/Clang libraries are located.", &options.llvmLibPath,
+        // Only dynamic linking is supported for now
+        // "ncurses-lib-path", "The path to the ncurses library.", &options.ncursesLibPath,
+        // "dynamic-clang", "Link dynamically to libclang. Defaults to yes.", &options.dynamicClang
+    );
+
+    if (help.helpWanted)
+        handleHelp(help, options);
+
+    return options;
+}
+
+/**
+ * Handles the help flag.
+ *
+ * This will print the help/usage information, if that was requested. It will
+ * also set the `help` field of the `options` struct to `true`, if help was
+ * requested.
+ *
+ * Params:
+ *  result = the result value from the call to `getopt`
+ *  options = the struct containing the parsed arguments
+ */
+void handleHelp(GetoptResult result, ref Options options)
+{
+    if (!result.helpWanted)
+        return;
+
+    options.help = true;
+
+    defaultGetoptPrinter("Usage: ./configure [options]\n\nOptions:",
+        result.options);
+}
+
+/**
+ * Enforces that a given set of libraries exist.
+ *
+ * Params:
+ *  name = a textual representation of the set of libraries to check for.
+ *      Will be used in error messages
+ *
+ *  path = the path to the directory where to look for the libraries
+ *  libraries = the actual libraries to look for
+ *
+ * Throws: Exception if any of the given libraries don't exist
+ */
+void enforceLibrariesExist(string name, string path,
+    const(string)[] libraries ...)
+{
+    auto errorMessage = format("All required %s libraries could not be " ~
+        "found in the path '%s'.\nRequired libraries are:\n%s", name, path,
+        libraries.join("\n"));
+
+    alias libraryExists = library => path.buildPath(library).exists;
+
+    enforce(libraries.all!(libraryExists), errorMessage);
+}
+
+/**
+ * Searches the `PATH` environment variable for the given filename.
+ *
+ * Params:
+ *  filename = the filename to search for in the `PATH`
+ *
+ * Return: the full path to the given filename if found, otherwise `null`
+ */
+string searchPath(string filename)
+{
+    auto path =
+        environment.get("PATH", "").
+        split(':').
+        map!(path => path.buildPath(filename)).
+        find!(exists);
+
+    return path.empty ? null : path.front;
+}

--- a/dub.json
+++ b/dub.json
@@ -11,7 +11,11 @@
 
     "buildRequirements": ["silenceWarnings"],
     "stringImportPaths": ["resources"],
-    "preGenerateCommands": ["git describe --tags > resources/VERSION"],
+
+    "preGenerateCommands": [
+        "git describe --tags > resources/VERSION"
+    ],
+
     "lflags-osx": ["-macosx_version_min", "10.7", "-lcrt1.o"],
 
     "buildTypes": {
@@ -28,10 +32,16 @@
             "targetName": "dstep",
             "sourcePaths": ["dstep", "clang"],
             "importPaths": ["dstep", "clang"],
+
+            "preBuildCommands-posix": [
+                "(! [ -s linker_flags.txt ] && ./configure) || true"
+            ],
+
             "dflags-windows-x86": ["-m32mscoff"],
-            "lflags-posix": ["-lclang", "-rpath", ".", "-rpath", "/usr/lib/llvm-3.7/lib", "-L.", "-L/usr/lib64/llvm", "-L/usr/lib/llvm-3.7/lib"],
             "lflags-windows-x86": ["/LIBPATH:C:\\PROGRA~2\\LLVM\\lib", "libclang.lib", "Ole32.lib"],
             "lflags-windows-x86_64": ["/LIBPATH:C:\\PROGRA~1\\LLVM\\lib", "libclang.lib", "Ole32.lib"],
+
+            "lflags-posix": ["@linker_flags.txt"]
         },
 
         {
@@ -40,7 +50,7 @@
             "targetName": "test",
             "sourceFiles": [ "unit_tests/HttpClient.d" ],
             "excludedSourceFiles": ["dstep/*", "clang/*"],
-            "dflags-windows-x86": ["-m32mscoff"],
+            "dflags-windows-x86": ["-m32mscoff"]
         },
 
         {
@@ -49,10 +59,17 @@
             "targetName": "unittest",
             "sourcePaths": ["dstep", "clang", "unit_tests"],
             "importPaths": ["dstep", "clang"],
+
+            "preBuildCommands-posix": [
+                "(! [ -s linker_flags.txt ] && ./configure) || true"
+            ],
+
             "dflags-windows-x86": ["-m32mscoff"],
-            "lflags-posix": ["-lclang", "-rpath", ".", "-L.", "-L/usr/lib64/llvm", "-L/usr/lib/llvm-3.7/lib"],
             "lflags-windows-x86": ["/LIBPATH:C:\\PROGRA~2\\LLVM\\lib", "libclang.lib", "Ole32.lib"],
             "lflags-windows-x86_64": ["/LIBPATH:C:\\PROGRA~1\\LLVM\\lib", "libclang.lib", "Ole32.lib"],
+
+
+            "lflags-posix": ["@linker_flags.txt"]
         }
     ],
 }


### PR DESCRIPTION
@Dicebot @ciechowoj I've created this pull request to get some feedback on this code. It's tagged as WIP because I've only tested it on macOS so far. Here's the commit message that contains the description how the configure script works:

> This is done by adding a "configure" script. When the "configure"
script is called it will look for libclang in the most common paths
for the given platform and pick the latest version available that is
supported by DStep. When the "configure" script is run it will write a
file, "config.txt", in the root directory of DStep. This file contains
linker flags according to the specified configuration.
>
> When Dub is run, a pre generate command will look if the "config.txt"
file exists, if it doesn't, Dub will automatically invoke the
"configure" script. This file is later passed as a flag to the linker,
which will pickup the linker flags for the specified configuration.
>
> It's possible to manually invoke the "configure" script to change the
default configuration. The following parameters can be configured:
> 
> * Static or dynamic linking of libclang
> 
> * The version/path of libclang to use by specifying the path to the
"llvm-config" binary that is shipped with LLVM
> 
> * The path to the "ncurses" library (only used when static linking
is used)