### PR TITLE
Fix #116: Option --space-after-function-name doesn't work with function pointer syntax.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -44,6 +44,7 @@
 * [Issue 85](https://github.com/jacob-carlborg/dstep/issues/85): dstep not converting `const T x[]` to `const (T)* x`
 * [Issue 107](https://github.com/jacob-carlborg/dstep/issues/107): Handle typedef of opaque structs.
 * [Issue 114](https://github.com/jacob-carlborg/dstep/issues/114): Crash on recursive typedef.
+* [Issue 116](https://github.com/jacob-carlborg/dstep/issues/116): Option --space-after-function-name doesn't work with function pointer syntax.
 * [Issue 117](https://github.com/jacob-carlborg/dstep/issues/117): fatal error: 'limits.h' file not found.
 
 ## Version 0.2.1

--- a/dstep/translator/Type.d
+++ b/dstep/translator/Type.d
@@ -430,7 +430,10 @@ string translateFunctionPointerType (Context context, Cursor cursor, FuncType fu
     auto result = translateType(context, cursor, func.resultType);
 
     Output output = new Output();
-    translateFunction(output, result, "function", params, func.isVariadic);
+    auto spacer = context.options.spaceAfterFunctionName ? " " : "";
+    translateFunction(output, result, "function",
+                      params, func.isVariadic, "", spacer);
+
     return output.data();
 }
 

--- a/unit_tests/UnitTests.d
+++ b/unit_tests/UnitTests.d
@@ -905,3 +905,34 @@ void foo ();
 D", options));
 
 }
+
+// Put or don't put a space after the 'function' keyword when
+// --space-after-function-name is or isn't specified.
+unittest
+{
+    Options options;
+    options.spaceAfterFunctionName = true;
+
+    assertTranslates(
+q"C
+typedef int (*foo)(int (*bar)(void));
+C",
+q"D
+extern (C):
+
+alias foo = int function (int function () bar);
+D", options);
+
+    options.spaceAfterFunctionName = false;
+
+    assertTranslates(
+q"C
+typedef int (*foo)(int (*bar)(void));
+C",
+q"D
+extern (C):
+
+alias foo = int function(int function() bar);
+D", options);
+
+}

--- a/unit_tests/issues/Issue116.d
+++ b/unit_tests/issues/Issue116.d
@@ -1,0 +1,43 @@
+/**
+ * Copyright: Copyright (c) 2016 Wojciech Szęszoł. All rights reserved.
+ * Authors: Wojciech Szęszoł
+ * Version: Initial created: Jan 26, 2017
+ * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0)
+ */
+
+import Common;
+import dstep.translator.Options;
+
+// Fix 116: Option --space-after-function-name doesn't work with function
+// pointer syntax.
+unittest
+{
+    Options options;
+    options.spaceAfterFunctionName = false;
+
+    assertTranslates(
+q"C
+int foo(void);
+
+typedef int (*Fun0)(void);
+typedef int (*Fun1)(int (*param)(void));
+
+struct Foo {
+  int (*bar)(void);
+};
+C",
+q"D
+extern (C):
+
+int foo();
+
+alias Fun0 = int function();
+alias Fun1 = int function(int function() param);
+
+struct Foo
+{
+    int function() bar;
+}
+D", options);
+
+}


### PR DESCRIPTION
As in the title.