### PR TITLE
Don't try aliasing D keywords

### DIFF
--- a/dstep/translator/MacroDefinition.d
+++ b/dstep/translator/MacroDefinition.d
@@ -2053,6 +2053,18 @@ bool translateFunctAlias(
     {
         Identifier ident = cast(Identifier) expr.expr;
 
+        if (ident.spelling == "assert")
+        {
+            // aliasing `assert` from C "assert.h" is commong enough to warrant
+            // a special case to use function instead of an alias
+            output.singleLine("void %s(T...)(T args)", definition.spelling);
+            output.singleLine("    if (T.length <= 2)");
+            output.singleLine("{");
+            output.singleLine("    assert(args);");
+            output.singleLine("}");
+            return true;
+        }
+
         if (ident !is null &&
             equal(definition.params, expr.args.map!(a => a.translate(context, params, imports))))
         {

--- a/unit_tests/MacroTranslTests.d
+++ b/unit_tests/MacroTranslTests.d
@@ -261,6 +261,17 @@ extern (D) auto STRINGIZE(T0, T1)(auto ref T0 major, auto ref T1 minor)
 }
 D");
 
+    assertTranslates(q"C
+#define PROTOBUF_C_ASSERT(condition) assert(condition)
+C", q"D
+extern (C):
+
+void PROTOBUF_C_ASSERT(T...)(T args)
+    if (T.length <= 2)
+{
+    assert(args);
+}
+D");
 }
 
 // Translate member access operators.


### PR DESCRIPTION
Most common issue this prevents is trying to alias `assert` keyword when
translating C macro.