### PR TITLE
Move LLVM version matrix to Travis CI and Appveyor build scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,30 @@ d:
   - ldc
 
 before_script: git fetch --unshallow
-script:
-  - "dub --config=test"
+script: dub --config=test --compiler=${DC}
 
 os:
   - linux
   - osx
 
+env:
+  - LLVM_VERSION=4.0.0
+  - LLVM_VERSION=3.9.1
+  - LLVM_VERSION=3.9.0
+
 matrix:
+  # beta and nightly builds for DMD and LDC
   include:
-    - d: dmd-beta
+    - &entry
+      d: dmd-beta
       os: linux
-    - d: dmd-nightly
-      os: linux
-    - d: ldc-beta
-      os: linux
+      env: LLVM_VERSION=4.0.0
+    - <<: *entry
+      d: dmd-nightly
+    - <<: *entry
+      d: ldc-beta
+
+  # missing binaries from http://releases.llvm.org
+  exclude:
+    - env: LLVM_VERSION=3.9.1
+      os: osx

--- a/appveyor.ps1
+++ b/appveyor.ps1
@@ -7,10 +7,11 @@ Invoke-WebRequest https://code.dlang.org/files/dub-1.4.0-windows-x86.zip -OutFil
 
 $env:PATH = "c:\dub;$($env:PATH)";
 $env:PATH = "c:\dmd2\windows\bin;$($env:PATH)";
+$env:LLVM_VERSION = $env:CONFIGURATION.split(" ")[1]
 
 $env:compilersetup = "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall";
 
-if ($env:arch -eq "x86") {
+if ($env:PLATFORM -eq "x86") {
   $env:compilersetupargs = "x86";
   $env:archswitch = "--arch=x86_mscoff";
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,15 @@
+platform:
+  - x64
+  - x86
 
-platform: x64
+configuration:
+  - LLVM 4.0.0
+  - LLVM 3.9.1
+  - LLVM 3.9.0
 
 environment:
-  matrix:
-  - DC: dmd
-    DVersion: 2.071.0
-    arch: x86
-  - DC: dmd
-    DVersion: 2.071.0
-    arch: x86_64
+  DVersion: 2.071.0
+  DC: dmd
 
 skip_tags: true
 


### PR DESCRIPTION
This will make it more clear from a build which versions of LLVM are tested.