### PR TITLE
Feature improve handling of known libraries

### DIFF
--- a/clang/TranslationUnit.d
+++ b/clang/TranslationUnit.d
@@ -99,6 +99,17 @@ struct TranslationUnit
         return clang_getNumDiagnostics(cx);
     }
 
+    bool isCompiled()
+    {
+        import std.algorithm;
+
+        alias predicate =
+            x => x.severity != CXDiagnosticSeverity.error &&
+                x.severity != CXDiagnosticSeverity.fatal;
+
+        return diagnosticSet.all!predicate();
+    }
+
     @property DeclarationVisitor declarations ()
     {
         return DeclarationVisitor(clang_getTranslationUnitCursor(cx));

--- a/dstep/translator/Context.d
+++ b/dstep/translator/Context.d
@@ -45,7 +45,7 @@ class Context
     {
         this.translUnit = translUnit;
         macroIndex = new MacroIndex(translUnit);
-        includeHandler_ = new IncludeHandler(options);
+        includeHandler_ = new IncludeHandler(headerIndex, options);
 
         this.options = options;
 

--- a/dstep/translator/IncludeHandler.d
+++ b/dstep/translator/IncludeHandler.d
@@ -12,6 +12,7 @@ import clang.c.Index;
 import clang.Cursor;
 import clang.Util;
 
+import dstep.translator.HeaderIndex;
 import dstep.translator.Options;
 import dstep.translator.Output;
 
@@ -21,6 +22,7 @@ class IncludeHandler
     private string[string] submodules;
     private bool[string] includes;
     private bool[string] imports;
+    private HeaderIndex headerIndex;
     immutable static string[string] knownIncludes;
 
     shared static this ()
@@ -102,11 +104,12 @@ class IncludeHandler
         ];
     }
 
-    this (Options options)
+    this (HeaderIndex headerIndex, Options options)
     {
         import std.format;
         import std.algorithm : filter;
 
+        this.headerIndex = headerIndex;
         this.options = options;
 
         if (options.packageName != "")
@@ -176,6 +179,14 @@ class IncludeHandler
             importsBlock(output, unhandled.keys);
 
         output.finalize();
+    }
+
+    void resolveDependency(in Cursor cursor)
+    {
+        auto module_ = headerIndex.searchKnownModules(cursor);
+
+        if (module_ !is null)
+            addImport(module_);
     }
 
 private:

--- a/test_files/graph/self_including.h
+++ b/test_files/graph/self_including.h
@@ -1,0 +1,6 @@
+#ifndef SELF_INCLUDING
+#define SELF_INCLUDING
+
+#include <graph/self_including.h>
+
+#endif SELF_INCLUDING

--- a/test_files/graph/self_including_main.h
+++ b/test_files/graph/self_including_main.h
@@ -1,0 +1,1 @@
+#include <graph/self_including.h>

--- a/unit_tests/IncludeGraphTests.d
+++ b/unit_tests/IncludeGraphTests.d
@@ -56,6 +56,7 @@ unittest
 
     // The file is reachable by itself.
     assert(includeGraph.isReachableBy(file, file));
+    assert(includeGraph.isReachableBy(subfile3, subfile3));
 
     // The file is reachable by its direct includer.
     assert(includeGraph.isReachableBy(subfile2, file));
@@ -74,10 +75,22 @@ unittest
 {
     import std.algorithm;
 
-    auto translationUnit = makeTranslationUnit("test_files/clang-c/Index.h");
+    auto translationUnit = makeTranslationUnit(
+        "test_files/clang-c/Index.h",
+        ["-Wno-missing-declarations", "-Itest_files"]);
+
     auto headerIndex = new HeaderIndex(translationUnit);
 
     auto timeT = translationUnit.cursor.children.filter!(x => x.spelling == "time_t").front;
 
-    assert(headerIndex.isFromStdLib(timeT, "time.h"));
+    assert(headerIndex.searchKnownModules(timeT) == "core.stdc.time");
+}
+
+unittest
+{
+    auto translationUnit = makeTranslationUnit(
+        "test_files/graph/self_including_main.h",
+        ["-Wno-missing-declarations", "-Itest_files"]);
+
+    new HeaderIndex(translationUnit);
 }

--- a/unit_tests/IncludeHandlerTests.d
+++ b/unit_tests/IncludeHandlerTests.d
@@ -1,0 +1,87 @@
+/**
+ * Copyright: Copyright (c) 2017 Wojciech Szęszoł. All rights reserved.
+ * Authors: Wojciech Szęszoł
+ * Version: Initial created: October 07, 2017
+ * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0)
+ */
+import Common;
+
+import clang.c.Index;
+import clang.Compiler;
+import clang.Index;
+import clang.TranslationUnit;
+import clang.Util;
+
+import dstep.translator.HeaderIndex;
+
+// Include standard library module when the dependency is used in macro.
+unittest
+{
+    assertTranslates(
+q"C
+#include <stdlib.h>
+
+#define FOO RAND_MAX
+C",
+q"D
+import core.stdc.stdlib;
+
+extern (C):
+
+enum FOO = RAND_MAX;
+D");
+
+    assertTranslates(
+q"C
+#include <limits.h>
+
+#define FOO INT_MAX
+C",
+q"D
+import core.stdc.limits;
+
+extern (C):
+
+enum FOO = INT_MAX;
+D");
+
+assertTranslates(
+q"C
+#include <stdint.h>
+
+#define FOO UINT32_MAX
+C",
+q"D
+import core.stdc.stdint;
+
+extern (C):
+
+enum FOO = UINT32_MAX;
+D");
+
+}
+
+version(Posix)
+{
+
+unittest
+{
+    // TODO: Following requires an improvement as the definition of _IOR in
+    // core.sys.posix.sys.ioctl has different interface
+    // (it takes two arguments).
+    assertTranslates(q"C
+#include <sys/ioctl.h>
+
+#define FOO _IOR('o', 61, 61)
+C",
+q"D
+import core.sys.posix.sys.ioctl;
+
+extern (C):
+
+enum FOO = _IOR('o', 61, 61);
+D");
+
+}
+
+}


### PR DESCRIPTION
Extends handling of the macro definition dependencies beyond `limits.h`.
Fixes problem with cycles in headers (`throw new Exception("The include graph isn't a DAG.");` has been triggered...).

This PR depends on another PR:
https://github.com/jacob-carlborg/dstep/pull/176

This PR is a step forward to solve:
https://github.com/jacob-carlborg/dstep/issues/141
