### PR TITLE
Fix #141: Improve type inference for macros, in particular handle type arguments.

### DIFF
--- a/clang/Compiler.d
+++ b/clang/Compiler.d
@@ -77,3 +77,16 @@ private:
         return virtualPath_ = buildPath(root, uniform(1, 10_000_000).to!string);
     }
 }
+
+string[] internalIncludeFlags()
+{
+    import std.algorithm;
+    import std.array;
+
+    return Compiler.init.extraIncludePaths.map!(path => "-I" ~ path).array();
+}
+
+CXUnsavedFile[] internalHeaders()
+{
+    return Compiler.init.extraHeaders();
+}

--- a/dstep/translator/Context.d
+++ b/dstep/translator/Context.d
@@ -8,8 +8,9 @@ module dstep.translator.Context;
 
 import clang.c.Index;
 import clang.Cursor;
-import clang.TranslationUnit;
+import clang.Index;
 import clang.SourceRange;
+import clang.TranslationUnit;
 
 import dstep.translator.CommentIndex;
 import dstep.translator.IncludeHandler;
@@ -72,6 +73,19 @@ class Context
         typeNames_ = collectGlobalTypes(translUnit);
 
         source = translUnit.source;
+    }
+
+    static Context fromString(string source, Options options = Options.init)
+    {
+        import clang.Compiler;
+
+        auto translationUnit = TranslationUnit.parseString(
+            Index(false, false),
+            source,
+            internalIncludeFlags(),
+            internalHeaders());
+
+        return new Context(translationUnit, options);
     }
 
     public string getAnonymousName (Cursor cursor)

--- a/dstep/translator/MacroIndex.d
+++ b/dstep/translator/MacroIndex.d
@@ -25,7 +25,7 @@ class MacroIndex
     private bool delegate (Cursor, Cursor) lessOp;
     private Cursor[] expansions;
     private Cursor[string] globalCursors_;
-    private Directive[] directives;
+    public Directive[] directives;
 
     this(TranslationUnit translUnit)
     {
@@ -117,7 +117,7 @@ class MacroIndex
             else if (2 <= directives.length)
             {
                 auto ifndef = cast (ConditionalDirective) directives[0];
-                auto define = cast (MacroDefinition) directives[1];
+                auto define = cast (DefineDirective) directives[1];
                 auto endif = directives[$ - 1];
 
                 if (ifndef && define &&

--- a/dstep/translator/Translator.d
+++ b/dstep/translator/Translator.d
@@ -31,6 +31,7 @@ import dstep.translator.Output;
 import dstep.translator.MacroDefinition;
 import dstep.translator.Record;
 import dstep.translator.Type;
+import dstep.translator.TypeInference;
 
 public import dstep.translator.Options;
 
@@ -55,6 +56,7 @@ class Translator
         string[string] deferredDeclarations;
     }
 
+    TypedMacroDefinition[string] typedMacroDefinitions;
     Context context;
 
     this (TranslationUnit translationUnit, Options options = Options.init)
@@ -76,6 +78,7 @@ class Translator
     Output translateCursors()
     {
         Output result = new Output(context.commentIndex);
+        typedMacroDefinitions = inferMacroSignatures(context);
 
         bool first = true;
 
@@ -303,10 +306,11 @@ class Translator
     {
         if (context.options.translateMacros)
         {
-            dstep.translator.MacroDefinition.translateMacroDefinition(
-                output,
-                context,
-                cursor);
+            if (auto definition = cursor.spelling in typedMacroDefinitions)
+            {
+                dstep.translator.MacroDefinition
+                    .translateMacroDefinition(output, context, *definition);
+            }
         }
     }
 

--- a/dstep/translator/TypeInference.d
+++ b/dstep/translator/TypeInference.d
@@ -1,0 +1,295 @@
+/**
+ * Copyright: Copyright (c) 2017 Wojciech Szęszoł. All rights reserved.
+ * Authors: Wojciech Szęszoł
+ * Version: Initial created: October 13, 2017
+ * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0)
+ */
+module dstep.translator.TypeInference;
+
+import std.container.dlist;
+import std.range;
+import std.traits;
+import std.variant;
+
+import clang.c.Index;
+import clang.Cursor;
+import clang.SourceLocation;
+import clang.SourceRange;
+import clang.Token;
+import clang.TranslationUnit;
+
+import dstep.translator.Context;
+import dstep.translator.MacroParser;
+import dstep.translator.Preprocessor;
+
+struct Defined
+{
+    string spelling;
+}
+
+struct Generic
+{
+}
+
+struct Meta
+{
+}
+
+alias InferredType = Algebraic!(Defined, Generic, Meta);
+
+struct InferredSignature
+{
+    InferredType result;
+    InferredType[] params;
+
+    static InferredSignature fromDefinition(MacroDefinition definition)
+    {
+        import std.array;
+        import std.range;
+
+        return InferredSignature(
+            InferredType(Generic.init),
+            repeat(InferredType(Generic.init), definition.params.length).array);
+    }
+}
+
+void inferMacroSignature(
+    InferenceContext context,
+    TypedMacroDefinition currentDefinition)
+{
+    inferMacroSignature(context, currentDefinition, currentDefinition.expr);
+}
+
+void inferMacroSignature(
+    InferenceContext context,
+    TypedMacroDefinition currentDefinition,
+    Expression expression)
+{
+    if (!expression.hasValue)
+        return;
+
+    void pass(T)(T operator) { }
+
+    bool isParamMeta(TypedMacroDefinition definition, string name)
+    {
+        import std.algorithm;
+        ptrdiff_t index = definition.params.countUntil(name);
+        return index != -1 && definition.signature.params[index].peek!Meta;
+    }
+
+    return expression.visit!(
+        delegate void(CallExpr expression)
+        {
+            auto spelling = expression.spelling;
+
+            if (spelling is null)
+                return;
+
+            auto definition = spelling in context.definitions;
+
+            if (definition is null)
+                return;
+
+            auto updated = false;
+
+            foreach (index, argument; expression.args)
+            {
+                if (auto argumentIdentifier
+                    = argument.debraced.peek!Identifier)
+                {
+                    if (isParamMeta(currentDefinition, argument.spelling) &&
+                        definition.signature.params[index].peek!Generic)
+                    {
+                        definition.signature.params[index] = Meta.init;
+                        updated = true;
+                    }
+                }
+                else if (auto argumentIdentifier
+                    = argument.debraced.peek!TypeIdentifier)
+                {
+                    if (definition.signature.params[index].peek!Generic)
+                    {
+                        definition.signature.params[index] = Meta.init;
+                        updated = true;
+                    }
+                }
+                else
+                {
+                    inferMacroSignature(context, currentDefinition, argument);
+                }
+            }
+
+            if (updated)
+                context.queue.insertBack(*definition);
+        },
+        delegate void(SubExpr subExpr)
+        {
+            inferMacroSignature(context, currentDefinition, subExpr.subexpr);
+        },
+        pass);
+}
+
+InferredType commonType(InferredType a, InferredType b)
+{
+    if (a == b)
+        return a;
+    else
+        return InferredType(Generic.init);
+}
+
+InferredType inferExpressionType(Expression expression)
+{
+    import std.format : format;
+
+    if (!expression.hasValue)
+        return InferredType.init;
+
+    InferredType inferBinaryOperator(T)(T operator)
+    {
+        return commonType(
+            operator.left.inferExpressionType(),
+            operator.right.inferExpressionType());
+    }
+
+    return expression.visit!(
+        delegate InferredType(Identifier identifier)
+        {
+            return InferredType(Generic.init);
+        },
+        delegate InferredType(TypeIdentifier identifier)
+        {
+            return InferredType(Meta.init);
+        },
+        delegate InferredType(Literal literal)
+        {
+            return InferredType(Defined("int"));
+        },
+        delegate InferredType(StringLiteral stringLiteral)
+        {
+            return InferredType(Defined("string"));
+        },
+        delegate InferredType(StringifyExpr stringifyExpr)
+        {
+            return InferredType(Defined("string"));
+        },
+        delegate InferredType(StringConcat stringConcat)
+        {
+            return InferredType(Defined("string"));
+        },
+        delegate InferredType(TokenConcat tokenConcat)
+        {
+            return InferredType(Defined("string"));
+        },
+        delegate InferredType(IndexExpr indexExpr)
+        {
+            return InferredType(Generic.init);
+        },
+        delegate InferredType(CallExpr callExpr)
+        {
+            return InferredType(Generic.init);
+        },
+        delegate InferredType(DotExpr dotExpr)
+        {
+            return InferredType(Generic.init);
+        },
+        delegate InferredType(ArrowExpr arrowExpr)
+        {
+            return InferredType(Generic.init);
+        },
+        delegate InferredType(SubExpr subExpr)
+        {
+            return subExpr.subexpr.inferExpressionType();
+        },
+        delegate InferredType(UnaryExpr unaryExpr)
+        {
+            if (unaryExpr.operator == "sizeof")
+                return InferredType(Defined("size_t"));
+            else
+                return unaryExpr.subexpr.inferExpressionType();
+        },
+        delegate InferredType(DefinedExpr literal)
+        {
+            return InferredType(Defined("int"));
+        },
+        delegate InferredType(SizeofType sizeofType)
+        {
+            return InferredType(Defined("size_t"));
+        },
+        delegate InferredType(CastExpr castExpr)
+        {
+            return InferredType(Generic.init);
+        },
+        inferBinaryOperator!MulExpr,
+        inferBinaryOperator!AddExpr,
+        inferBinaryOperator!SftExpr,
+        inferBinaryOperator!RelExpr,
+        inferBinaryOperator!EqlExpr,
+        inferBinaryOperator!AndExpr,
+        inferBinaryOperator!XorExpr,
+        inferBinaryOperator!OrExpr,
+        inferBinaryOperator!LogicalAndExpr,
+        inferBinaryOperator!LogicalOrExpr,
+        delegate InferredType(CondExpr condExpr)
+        {
+            return commonType(
+                condExpr.left.inferExpressionType(),
+                condExpr.right.inferExpressionType());
+        });
+}
+
+class InferenceContext
+{
+    Cursor[string] globalTypes;
+    DList!TypedMacroDefinition queue;
+    TypedMacroDefinition[string] definitions;
+}
+
+class TypedMacroDefinition
+{
+    MacroDefinition definition;
+    InferredSignature signature;
+    alias definition this;
+
+    static TypedMacroDefinition fromDefinition(MacroDefinition definition)
+    {
+        auto result = new TypedMacroDefinition();
+        result.definition = definition;
+        result.signature = InferredSignature.fromDefinition(definition);
+        return result;
+    }
+}
+
+TypedMacroDefinition[string] inferMacroSignatures(Context context)
+{
+    import std.array;
+    import std.algorithm;
+    import std.range;
+
+    auto macroDefinitions = parseMacroDefinitions(
+        context.translUnit.cursor.children(true),
+        context.typeNames());
+
+    auto inferenceContext = new InferenceContext();
+    inferenceContext.globalTypes = context.typeNames();
+    inferenceContext.queue = DList!TypedMacroDefinition(
+        macroDefinitions.map!(TypedMacroDefinition.fromDefinition));
+    inferenceContext.definitions = assocArray(
+        zip(
+            inferenceContext.queue[]
+                .map!((TypedMacroDefinition x) => x.definition.spelling),
+            inferenceContext.queue[]));
+
+    while (!inferenceContext.queue.empty)
+    {
+        inferMacroSignature(
+            inferenceContext,
+            inferenceContext.queue.front);
+
+        inferenceContext.queue.removeFront();
+    }
+
+    foreach (definition; inferenceContext.definitions)
+        definition.signature.result = inferExpressionType(definition.expr);
+
+    return inferenceContext.definitions;
+}

--- a/tests/unit/Assert.d
+++ b/tests/unit/Assert.d
@@ -74,15 +74,14 @@ void assertTranslatesMacroExpression(
 
     auto definition = parsePartialMacroDefinition(tokens, context.typeNames);
 
-    Set!string imports;
-    Set!string params;
+    auto expressionContext = ExpressionContext.make(context);
 
     string actual = null;
 
     if (definition !is null)
     {
         if (definition.expr.hasValue)
-            actual = definition.expr.debraced.translate(context, params, imports);
+            actual = definition.expr.debraced.translate(expressionContext);
     }
 
     assertEq(expected, actual, false, file, line);

--- a/tests/unit/Assert.d
+++ b/tests/unit/Assert.d
@@ -20,6 +20,7 @@ import dstep.translator.MacroParser;
 import dstep.translator.Output;
 import dstep.translator.Translator;
 import dstep.translator.Type;
+import dstep.translator.TypeInference;
 
 void assertTranslatesMacroDefinition(
     string source,
@@ -39,7 +40,10 @@ void assertTranslatesMacroDefinition(
     if (children.length != 1)
         throw new AssertError("Assertion failure", file, line);
 
-    translateMacroDefinition(output, context, children[0]);
+    auto definitions = inferMacroSignatures(context);
+
+    if (auto definition = children[0].spelling in definitions)
+        translateMacroDefinition(output, context, *definition);
 
     assertEq(expected, output.data, false, file, line);
 }

--- a/tests/unit/Common.d
+++ b/tests/unit/Common.d
@@ -25,6 +25,7 @@ import dstep.translator.CommentIndex;
 import dstep.translator.Context;
 import dstep.translator.IncludeHandler;
 import dstep.translator.MacroDefinition;
+import dstep.translator.MacroParser;
 import dstep.translator.Options;
 import dstep.translator.Output;
 import dstep.translator.Translator;

--- a/tests/unit/IncludeHandlerTests.d
+++ b/tests/unit/IncludeHandlerTests.d
@@ -72,14 +72,14 @@ unittest
     assertTranslates(q"C
 #include <sys/ioctl.h>
 
-#define FOO _IOR('o', 61, 61)
+#define FOO _IOR('o', 61, int)
 C",
 q"D
 import core.sys.posix.sys.ioctl;
 
 extern (C):
 
-enum FOO = _IOR('o', 61, 61);
+enum FOO = _IOR!int('o', 61);
 D");
 
 }

--- a/tests/unit/TypeInferenceTests.d
+++ b/tests/unit/TypeInferenceTests.d
@@ -1,0 +1,217 @@
+/**
+ * Copyright: Copyright (c) 2017 Wojciech Szęszoł. All rights reserved.
+ * Authors: Wojciech Szęszoł
+ * Version: Initial created: October 13, 2017
+ * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0)
+ */
+import core.exception;
+
+import std.container.dlist;
+import std.variant;
+
+import Common;
+import Assert;
+
+import dstep.translator.MacroDefinition;
+
+unittest
+{
+    assertTranslates(q"C
+#define FOO(x) BAR(int)
+C", q"D
+extern (C):
+
+extern (D) auto FOO(T)(auto ref T x)
+{
+    return BAR(int);
+}
+D");
+}
+
+unittest
+{
+    assertTranslates(q"C
+#define BAR(x) 0
+#define FOO(x) BAR(int)
+C", q"D
+extern (C):
+
+extern (D) int BAR(x)()
+{
+    return 0;
+}
+
+extern (D) auto FOO(T)(auto ref T x)
+{
+    return BAR!int();
+}
+D");
+}
+
+unittest
+{
+    assertTranslates(q"C
+#define BAR(x, y, z) x * y * sizeof(z)
+
+#define BAZ BAR(0, 1, float)
+C", q"D
+extern (C):
+
+extern (D) auto BAR(z, T0, T1)(auto ref T0 x, auto ref T1 y)
+{
+    return x * y * z.sizeof;
+}
+
+enum BAZ = BAR!float(0, 1);
+D");
+
+}
+
+unittest
+{
+    assertTranslates(q"C
+typedef struct { } foo_t;
+
+#define BAR(x, y, z) x * y * sizeof(z)
+
+#define BAZ BAR(0, 1, foo_t)
+C", q"D
+extern (C):
+
+struct foo_t
+{
+}
+
+extern (D) auto BAR(z, T0, T1)(auto ref T0 x, auto ref T1 y)
+{
+    return x * y * z.sizeof;
+}
+
+enum BAZ = BAR!foo_t(0, 1);
+D");
+
+}
+
+unittest
+{
+    assertTranslates(q"C
+typedef unsigned int __u32;
+
+#define BAR(x) sizeof(x)
+
+#define BAZ BAR(__u32)
+C", q"D
+extern (C):
+
+extern (D) size_t BAR(x)()
+{
+    return x.sizeof;
+}
+
+enum BAZ = BAR!uint();
+D");
+
+}
+
+unittest
+{
+    assertTranslates(q"C
+#define FOO() 0
+
+#define BAR(x) BAZ(0, 1, x)
+
+#define BAZ(x, y, z) sizeof(z) * x * y
+
+#define QUX(x) BAR(float)
+C", q"D
+extern (C):
+
+extern (D) int FOO()
+{
+    return 0;
+}
+
+extern (D) auto BAR(x)()
+{
+    return BAZ!x(0, 1);
+}
+
+extern (D) auto BAZ(z, T0, T1)(auto ref T0 x, auto ref T1 y)
+{
+    return z.sizeof * x * y;
+}
+
+extern (D) auto QUX(T)(auto ref T x)
+{
+    return BAR!float();
+}
+D");
+
+}
+
+unittest
+{
+    assertTranslates(q"C
+#define FOO(type) sizeof(type)
+
+#define BAR FOO(unsigned int)
+#define BAZ FOO(unsigned short)
+#define QUX FOO(long)
+C", q"D
+import core.stdc.config;
+
+extern (C):
+
+extern (D) size_t FOO(type)()
+{
+    return type.sizeof;
+}
+
+enum BAR = FOO!uint();
+enum BAZ = FOO!ushort();
+enum QUX = FOO!c_long();
+D");
+}
+
+unittest
+{
+    assertTranslates(q"C
+#define FOO(a, b, c, d) 0
+
+#define BAR(t) sizeof(t)
+
+#define BAZ(x2,x3) FOO(x0,(x2),(x3),0)
+#define QUX(x2,x3,type) FOO(x4,(x2),(x3),(BAR(type)))
+
+#define ENUM0 QUX('a', 0, char)
+#define ENUM1 QUX('b', 1, short)
+#define ENUM2 QUX('c', 2, int)
+C", q"D
+extern (C):
+
+extern (D) int FOO(T0, T1, T2, T3)(auto ref T0 a, auto ref T1 b, auto ref T2 c, auto ref T3 d)
+{
+    return 0;
+}
+
+extern (D) size_t BAR(t)()
+{
+    return t.sizeof;
+}
+
+extern (D) auto BAZ(T0, T1)(auto ref T0 x2, auto ref T1 x3)
+{
+    return FOO(x0, x2, x3, 0);
+}
+
+extern (D) auto QUX(type, T0, T1)(auto ref T0 x2, auto ref T1 x3)
+{
+    return FOO(x4, x2, x3, BAR!type());
+}
+
+enum ENUM0 = QUX!char('a', 0);
+enum ENUM1 = QUX!short('b', 1);
+enum ENUM2 = QUX!int('c', 2);
+D");
+
+}

--- a/tests/unit/issues/Issue141.d
+++ b/tests/unit/issues/Issue141.d
@@ -1,0 +1,86 @@
+/**
+ * Copyright: Copyright (c) 2017 Wojciech Szęszoł. All rights reserved.
+ * Authors: Wojciech Szęszoł
+ * Version: Initial created: September 23, 2017
+ * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0)
+ */
+
+import Common;
+import dstep.translator.Options;
+
+// Fix 141: Use of _IO, _IOR, etc.
+unittest
+{
+    assertTranslates(q"C
+#define _IOC_NRSHIFT	0
+#define _IOC_TYPESHIFT	1
+#define _IOC_SIZESHIFT	2
+#define _IOC_DIRSHIFT	3
+
+#define _IOC_NONE	0U
+#define _IOC_READ	2U
+
+#define _IOC(dir,type,nr,size) \
+	(((dir)  << _IOC_DIRSHIFT) | \
+	 ((type) << _IOC_TYPESHIFT) | \
+	 ((nr)   << _IOC_NRSHIFT) | \
+	 ((size) << _IOC_SIZESHIFT))
+
+#define _IOC_TYPECHECK(t) (sizeof(t))
+
+#define _IO(type,nr)		_IOC(_IOC_NONE,(type),(nr),0)
+#define _IOR(type,nr,size)	_IOC(_IOC_READ,(type),(nr),(_IOC_TYPECHECK(size)))
+
+typedef struct { } foo_status_t;
+typedef unsigned int __u32;
+typedef unsigned short __u16;
+
+#define FE_READ_STATUS _IOR('o', 69, foo_status_t)
+#define FE_READ_BER _IOR('o', 70, __u32)
+#define FE_READ_SIGNAL_STRENGTH _IOR('o', 71, __u16)
+#define FE_READ_SNR _IOR('o', 72, __u16)
+#define FE_READ_UNCORRECTED_BLOCKS _IOR('o', 73, __u32)
+C",
+q"D
+extern (C):
+
+enum _IOC_NRSHIFT = 0;
+enum _IOC_TYPESHIFT = 1;
+enum _IOC_SIZESHIFT = 2;
+enum _IOC_DIRSHIFT = 3;
+
+enum _IOC_NONE = 0U;
+enum _IOC_READ = 2U;
+
+extern (D) auto _IOC(T0, T1, T2, T3)(auto ref T0 dir, auto ref T1 type, auto ref T2 nr, auto ref T3 size)
+{
+    return (dir << _IOC_DIRSHIFT) | (type << _IOC_TYPESHIFT) | (nr << _IOC_NRSHIFT) | (size << _IOC_SIZESHIFT);
+}
+
+extern (D) size_t _IOC_TYPECHECK(t)()
+{
+    return t.sizeof;
+}
+
+extern (D) auto _IO(T0, T1)(auto ref T0 type, auto ref T1 nr)
+{
+    return _IOC(_IOC_NONE, type, nr, 0);
+}
+
+extern (D) auto _IOR(size, T0, T1)(auto ref T0 type, auto ref T1 nr)
+{
+    return _IOC(_IOC_READ, type, nr, _IOC_TYPECHECK!size());
+}
+
+struct foo_status_t
+{
+}
+
+enum FE_READ_STATUS = _IOR!foo_status_t('o', 69);
+enum FE_READ_BER = _IOR!uint('o', 70);
+enum FE_READ_SIGNAL_STRENGTH = _IOR!ushort('o', 71);
+enum FE_READ_SNR = _IOR!ushort('o', 72);
+enum FE_READ_UNCORRECTED_BLOCKS = _IOR!uint('o', 73);
+D");
+
+}


### PR DESCRIPTION
The commit learns dstep to infer the signature of the macro basing on usage. It is still quite rudimentary implementation but it handles the cases that were wrong before anyway. Example:

```
assertTranslates(q"C
#define BAR(x, y, z) x * y * sizeof(z)

#define BAZ BAR(0, 1, float)
C", q"D
extern (C):

extern (D) auto BAR(z, T0, T1)(auto ref T0 x, auto ref T1 y)
{
    return x * y * z.sizeof;
}

enum BAZ = BAR!float(0, 1);
D");
```

More examples in unit tests.




