### PR TITLE
Add missing check for null pointer

### DIFF
--- a/dstep/translator/MacroDefinition.d
+++ b/dstep/translator/MacroDefinition.d
@@ -521,6 +521,7 @@ bool translateFunctAlias(
     if (expr !is null)
     {
         Identifier* ident = expr.expr.peek!Identifier;
+        if (ident is null) return false;
 
         if (ident.spelling == "assert")
         {
@@ -541,8 +542,7 @@ bool translateFunctAlias(
             return true;
         }
 
-        if (ident !is null &&
-            equal(definition.params, expr.args
+        if (equal(definition.params, expr.args
                 .map!(a => a.translate(expressionContext))))
         {
             version (D1)

--- a/tests/unit/MacroTranslTests.d
+++ b/tests/unit/MacroTranslTests.d
@@ -159,6 +159,21 @@ D");
 
 }
 
+// Translate function call.
+unittest
+{
+    assertTranslates(q"C
+#define FOO(a) (bar)(a)
+C", q"D
+extern (C):
+
+extern (D) auto FOO(T)(auto ref T a)
+{
+    return bar(a);
+}
+D");
+}
+
 // Translate cast operator.
 unittest
 {
@@ -170,7 +185,6 @@ extern (D) auto FOO(T)(auto ref T a)
     return cast(float) a;
 }
 D");
-
 }
 
 // Translate unary operators.


### PR DESCRIPTION
This patch adds a reduced test case for a C macro defining a function
call `(bar)(a)`, i.e., calling the function `bar` on `a`. The extra
parentheses make the test result in a segmentation fault due to null
pointer dereferencing. To fix the problem the null pointer check is
performed as part of an early return. This makes the code more robust
and allows removing a later null check.