### PR TITLE
Sort entries in relativeLocationAccessorImpl

### DIFF
--- a/clang/TranslationUnit.d
+++ b/clang/TranslationUnit.d
@@ -245,6 +245,10 @@ struct TranslationUnit
         foreach (index, location; locations)
             map[location.path] ~= Entry(index, location);
 
+        import std.algorithm.sorting;
+        foreach (path, entries; map)
+            entries.sort();
+
         size_t findIndex(SourceLocation a)
         {
             auto entries = map[a.path];


### PR DESCRIPTION
Without this PR, I got this exception


```
dstep: an unknown error occurred: core.exception.AssertError@/usr/include/dlang/dmd/std/range/package.d(10439): Range is not sorted
----------------
??:? _d_assert_msg [0xc5ba2228]
/usr/include/dlang/dmd/std/range/package.d:10439 pure void std.range.SortedRange!(clang.TranslationUnit.TranslationUnit.relativeLocationAccessorImpl!(clang.Visitor.Visitor).relativeLocationAccessorImpl(clang.Visitor.Visitor).Entry[], "a < b").SortedRange.dbgVerifySorted() [0xc5ad4c87]
/usr/include/dlang/dmd/std/range/package.d:10413 pure nothrow ref std.range.SortedRange!(clang.TranslationUnit.TranslationUnit.relativeLocationAccessorImpl!(clang.Visitor.Visitor).relativeLocationAccessorImpl(clang.Visitor.Visitor).Entry[], "a < b").SortedRange std.range.SortedRange!(clang.TranslationUnit.TranslationUnit.relativeLocationAccessorImpl!(clang.Visitor.Visitor).relativeLocationAccessorImpl(clang.Visitor.Visitor).Entry[], "a < b").SortedRange.__ctor(clang.TranslationUnit.TranslationUnit.relativeLocationAccessorImpl!(clang.Visitor.Visitor).relativeLocationAccessorImpl(clang.Visitor.Visitor).Entry[]) [0xc5ad4bc7]
/usr/include/dlang/dmd/std/range/package.d:11043 pure nothrow std.range.SortedRange!(clang.TranslationUnit.TranslationUnit.relativeLocationAccessorImpl!(clang.Visitor.Visitor).relativeLocationAccessorImpl(clang.Visitor.Visitor).Entry[], "a < b").SortedRange std.range.assumeSorted!("a < b", clang.TranslationUnit.TranslationUnit.relativeLocationAccessorImpl!(clang.Visitor.Visitor).relativeLocationAccessorImpl(clang.Visitor.Visitor).Entry[]).assumeSorted(clang.TranslationUnit.TranslationUnit.relativeLocationAccessorImpl!(clang.Visitor.Visitor).relativeLocationAccessorImpl(clang.Visitor.Visitor).Entry[]) [0xc5ad4b87]
clang/TranslationUnit.d:254 ulong clang.TranslationUnit.TranslationUnit.relativeLocationAccessorImpl!(clang.Visitor.Visitor).relativeLocationAccessorImpl(clang.Visitor.Visitor).findIndex(clang.SourceLocation.SourceLocation) [0xc5b3055a]
clang/TranslationUnit.d:261 ulong clang.TranslationUnit.TranslationUnit.relativeLocationAccessorImpl!(clang.Visitor.Visitor).relativeLocationAccessorImpl(clang.Visitor.Visitor).accessor(clang.SourceLocation.SourceLocation) [0xc5b305cd]
clang/TranslationUnit.d:300 bool clang.TranslationUnit.TranslationUnit.relativeCursorLocationLessOp().lessOp(clang.Cursor.Cursor, clang.Cursor.Cursor) [0xc5b2eee3]
dstep/translator/MacroIndex.d:45 bool dstep.translator.MacroIndex.MacroIndex.__ctor(clang.TranslationUnit.TranslationUnit).__lambda3!(clang.Cursor.Cursor, clang.Cursor.Cursor).__lambda3(clang.Cursor.Cursor, clang.Cursor.Cursor) [0xc5b64383]
/usr/include/dlang/dmd/std/algorithm/sorting.d:2093 void std.algorithm.sorting.quickSortImpl!(dstep.translator.MacroIndex.MacroIndex.__ctor(clang.TranslationUnit.TranslationUnit).__lambda3, clang.Cursor.Cursor[]).quickSortImpl(clang.Cursor.Cursor[], ulong) [0xc5b645b0]
/usr/include/dlang/dmd/std/algorithm/sorting.d:1875 std.range.SortedRange!(clang.Cursor.Cursor[], dstep.translator.MacroIndex.MacroIndex.__ctor(clang.TranslationUnit.TranslationUnit).__lambda3).SortedRange std.algorithm.sorting.sort!(dstep.translator.MacroIndex.MacroIndex.__ctor(clang.TranslationUnit.TranslationUnit).__lambda3, 0, clang.Cursor.Cursor[]).sort(clang.Cursor.Cursor[]) [0xc5b63eff]
dstep/translator/MacroIndex.d:45 dstep.translator.MacroIndex.MacroIndex dstep.translator.MacroIndex.MacroIndex.__ctor(clang.TranslationUnit.TranslationUnit) [0xc5b5feb3]
dstep/translator/Context.d:49 dstep.translator.Context.Context dstep.translator.Context.Context.__ctor(clang.TranslationUnit.TranslationUnit, dstep.translator.Options.Options, dstep.translator.Translator.Translator) [0xc5b4dd2f]
dstep/translator/Translator.d:70 dstep.translator.Translator.Translator dstep.translator.Translator.Translator.__ctor(clang.TranslationUnit.TranslationUnit, dstep.translator.Options.Options) [0xc5b9164a]
dstep/driver/Application.d:66 int dstep.driver.Application.Application.run().__foreachbody2(std.typecons.Tuple!(immutable(char)[], immutable(char)[], clang.TranslationUnit.TranslationUnit).Tuple) [0xc5b38038]
/usr/include/dlang/dmd/std/parallelism.d-mixin-4024:4070 void std.parallelism.ParallelForeach!(std.range.ZipShortest!(1, immutable(char)[][], immutable(char)[][], clang.TranslationUnit.TranslationUnit[]).ZipShortest).ParallelForeach.opApply(scope int delegate(std.typecons.Tuple!(immutable(char)[], immutable(char)[], clang.TranslationUnit.TranslationUnit).Tuple)).doIt() [0xc5b387c5]
??:? void std.parallelism.run!(void delegate()).run(void delegate()) [0xc5bb853f]
??:? void std.parallelism.Task!(std.parallelism.run, void delegate()).Task.impl(void*) [0xc5bb8053]
??:? void std.parallelism.AbstractTask.job() [0xc5bdf796]
??:? void std.parallelism.TaskPool.doJob(std.parallelism.AbstractTask*) [0xc5bb6c5b]
??:? void std.parallelism.TaskPool.executeWorkLoop() [0xc5bb6db5]
??:? void std.parallelism.TaskPool.startWorkLoop() [0xc5bb6d5c]
??:? void core.thread.Thread.run() [0xc5bcfa5b]
??:? thread_entryPoint [0xc5be9507]
??:? [0xc535a9c]
core.exception.AssertError@/usr/include/dlang/dmd/std/range/package.d(10439): Range is not sorted
----------------
??:? _d_assert_msg [0xc5ba2228]
/usr/include/dlang/dmd/std/range/package.d:10439 pure void std.range.SortedRange!(clang.TranslationUnit.TranslationUnit.relativeLocationAccessorImpl!(clang.Visitor.Visitor).relativeLocationAccessorImpl(clang.Visitor.Visitor).Entry[], "a < b").SortedRange.dbgVerifySorted() [0xc5ad4c87]
/usr/include/dlang/dmd/std/range/package.d:10413 pure nothrow ref std.range.SortedRange!(clang.TranslationUnit.TranslationUnit.relativeLocationAccessorImpl!(clang.Visitor.Visitor).relativeLocationAccessorImpl(clang.Visitor.Visitor).Entry[], "a < b").SortedRange std.range.SortedRange!(clang.TranslationUnit.TranslationUnit.relativeLocationAccessorImpl!(clang.Visitor.Visitor).relativeLocationAccessorImpl(clang.Visitor.Visitor).Entry[], "a < b").SortedRange.__ctor(clang.TranslationUnit.TranslationUnit.relativeLocationAccessorImpl!(clang.Visitor.Visitor).relativeLocationAccessorImpl(clang.Visitor.Visitor).Entry[]) [0xc5ad4bc7]
/usr/include/dlang/dmd/std/range/package.d:11043 pure nothrow std.range.SortedRange!(clang.TranslationUnit.TranslationUnit.relativeLocationAccessorImpl!(clang.Visitor.Visitor).relativeLocationAccessorImpl(clang.Visitor.Visitor).Entry[], "a < b").SortedRange std.range.assumeSorted!("a < b", clang.TranslationUnit.TranslationUnit.relativeLocationAccessorImpl!(clang.Visitor.Visitor).relativeLocationAccessorImpl(clang.Visitor.Visitor).Entry[]).assumeSorted(clang.TranslationUnit.TranslationUnit.relativeLocationAccessorImpl!(clang.Visitor.Visitor).relativeLocationAccessorImpl(clang.Visitor.Visitor).Entry[]) [0xc5ad4b87]
clang/TranslationUnit.d:254 ulong clang.TranslationUnit.TranslationUnit.relativeLocationAccessorImpl!(clang.Visitor.Visitor).relativeLocationAccessorImpl(clang.Visitor.Visitor).findIndex(clang.SourceLocation.SourceLocation) [0xc5b3055a]
clang/TranslationUnit.d:261 ulong clang.TranslationUnit.TranslationUnit.relativeLocationAccessorImpl!(clang.Visitor.Visitor).relativeLocationAccessorImpl(clang.Visitor.Visitor).accessor(clang.SourceLocation.SourceLocation) [0xc5b305cd]
clang/TranslationUnit.d:300 bool clang.TranslationUnit.TranslationUnit.relativeCursorLocationLessOp().lessOp(clang.Cursor.Cursor, clang.Cursor.Cursor) [0xc5b2eee3]
dstep/translator/MacroIndex.d:45 bool dstep.translator.MacroIndex.MacroIndex.__ctor(clang.TranslationUnit.TranslationUnit).__lambda3!(clang.Cursor.Cursor, clang.Cursor.Cursor).__lambda3(clang.Cursor.Cursor, clang.Cursor.Cursor) [0xc5b64383]
/usr/include/dlang/dmd/std/algorithm/sorting.d:2093 void std.algorithm.sorting.quickSortImpl!(dstep.translator.MacroIndex.MacroIndex.__ctor(clang.TranslationUnit.TranslationUnit).__lambda3, clang.Cursor.Cursor[]).quickSortImpl(clang.Cursor.Cursor[], ulong) [0xc5b645b0]
/usr/include/dlang/dmd/std/algorithm/sorting.d:1875 std.range.SortedRange!(clang.Cursor.Cursor[], dstep.translator.MacroIndex.MacroIndex.__ctor(clang.TranslationUnit.TranslationUnit).__lambda3).SortedRange std.algorithm.sorting.sort!(dstep.translator.MacroIndex.MacroIndex.__ctor(clang.TranslationUnit.TranslationUnit).__lambda3, 0, clang.Cursor.Cursor[]).sort(clang.Cursor.Cursor[]) [0xc5b63eff]
dstep/translator/MacroIndex.d:45 dstep.translator.MacroIndex.MacroIndex dstep.translator.MacroIndex.MacroIndex.__ctor(clang.TranslationUnit.TranslationUnit) [0xc5b5feb3]
dstep/translator/Context.d:49 dstep.translator.Context.Context dstep.translator.Context.Context.__ctor(clang.TranslationUnit.TranslationUnit, dstep.translator.Options.Options, dstep.translator.Translator.Translator) [0xc5b4dd2f]
dstep/translator/Translator.d:70 dstep.translator.Translator.Translator dstep.translator.Translator.Translator.__ctor(clang.TranslationUnit.TranslationUnit, dstep.translator.Options.Options) [0xc5b9164a]
dstep/driver/Application.d:66 int dstep.driver.Application.Application.run().__foreachbody2(std.typecons.Tuple!(immutable(char)[], immutable(char)[], clang.TranslationUnit.TranslationUnit).Tuple) [0xc5b38038]
/usr/include/dlang/dmd/std/parallelism.d-mixin-4024:4070 void std.parallelism.ParallelForeach!(std.range.ZipShortest!(1, immutable(char)[][], immutable(char)[][], clang.TranslationUnit.TranslationUnit[]).ZipShortest).ParallelForeach.opApply(scope int delegate(std.typecons.Tuple!(immutable(char)[], immutable(char)[], clang.TranslationUnit.TranslationUnit).Tuple)).doIt() [0xc5b387c5]
??:? void std.parallelism.run!(void delegate()).run(void delegate()) [0xc5bb853f]
??:? void std.parallelism.Task!(std.parallelism.run, void delegate()).Task.impl(void*) [0xc5bb8053]
??:? void std.parallelism.AbstractTask.job() [0xc5bdf796]
??:? void std.parallelism.TaskPool.doJob(std.parallelism.AbstractTask*) [0xc5bb6c5b]
??:? void std.parallelism.TaskPool.executeWorkLoop() [0xc5bb6db5]
??:? void std.parallelism.TaskPool.startWorkLoop() [0xc5bb6d5c]
??:? void core.thread.Thread.run() [0xc5bcfa5b]
??:? thread_entryPoint [0xc5be9507]
??:? [0xc535a9c]
```
