### PR TITLE
Replace rdmd usage with dmd to decrease dependencies

### DIFF
--- a/configure
+++ b/configure
@@ -2,4 +2,15 @@
 
 set -e
 
-rdmd configure.d "$@"
+if test -z "$DC"; then
+    if test -x "$(which dmd)"; then
+        DC=dmd
+    elif test -x "$(which ldc2)"; then
+        DC=ldc2
+    else
+        echo "Neither DMD nor LDC found to compile configure.d"
+        exit -1
+    fi
+fi
+
+$DC -run configure.d "$@"


### PR DESCRIPTION
Well, the true reason is that I just didn't manage to install rdmd on archlinux.
But using dmd directly still is better than yet another binary, right?
