### PR TITLE
Improve Windows build script

### DIFF
--- a/tools/generate_version.bat
+++ b/tools/generate_version.bat
@@ -1,7 +1,11 @@
-cd "%DUB_PACKAGE_DIR%"
+@echo off
+
+pushd "%DUB_PACKAGE_DIR%"
 
 if exist .git (
   git describe --tags > resources\VERSION
 ) else (
   echo unknown > resources\VERSION
 )
+
+popd


### PR DESCRIPTION
The old `generate_version.bat` script would leave the current directory in the dstep directory after finishing the build command, and in some cases the `cd` command will not change the directory when current directory is in different drive.

This change fixes these issues and also disables echoing of the commands back to terminal.