### PR TITLE
Update FreeBSD configuration

### DIFF
--- a/configure.d
+++ b/configure.d
@@ -203,16 +203,16 @@ static:
         ];
 
         immutable llvmLibPaths = [
-            "/usr/lib/llvm-4.0/lib",
-            "/usr/lib/llvm-3.9/lib",
-            "/usr/lib/llvm-3.8/lib",
-            "/usr/lib/llvm-3.7/lib"
+            "/usr/local/llvm80/lib",
+            "/usr/local/llvm70/lib",
+            "/usr/local/llvm60/lib",
+            "/usr/local/llvm50/lib",
         ] ~ standardPaths;
 
         immutable additionalLibPaths = standardPaths;
 
-        enum ncursesLib = LibraryName("ncurses", "libncurses.a");
-        enum cppLib = "stdc++";
+        enum additionalLib = LibraryName("ncurses", "libncurses.a");
+        enum cppLib = "c++";
     }
 
     else


### PR DESCRIPTION
- `ncursesLib` → `additionalLib` was missed
- `stdc++` hasn't been the default c++ library for *ages*
- I don't recall LLVM paths ever being `/usr/lib/llvm-0.0`, FreeBSD has always installed packages to `/usr/local` and they were `/usr/local/llvm00`..
- (you might want to update llvm paths on all platforms, it mentions really really old versions)