### PR TITLE
Replace opIn with opBinary operator

### DIFF
--- a/dstep/translator/Output.d
+++ b/dstep/translator/Output.d
@@ -937,7 +937,7 @@ D"[0 .. $ - 1]);
             }
         }
 
-        void opIn (void delegate () nested)
+        void opBinary(string op : "in")(void delegate () nested)
         {
             nested();
         }


### PR DESCRIPTION
`opIn` is due to be removed in https://github.com/dlang/dmd/pull/12902.