### PR TITLE
Add termux libclang path

### DIFF
--- a/configure.d
+++ b/configure.d
@@ -200,7 +200,8 @@ static:
             "/usr/local/lib",
             "/usr/lib/x86_64-linux-gnu", // Debian
             "/usr/lib64", // Fedora
-            "/usr/lib32" // Fedora
+            "/usr/lib32", // Fedora
+            "/data/data/com.termux/files/usr/lib", // Termux
         ];
 
         enum debianPaths = [


### PR DESCRIPTION
Hi, thanks for this very useful project.
Termux allows to use a Linux environment on android devices. It uses the path "/data/data/com.termux/files/usr", or $PREFIX instead of the conventional paths usually found on linux because of the way android works. Unrooted devices don't have access to /usr. Therefore, during configuration, the path to libclang isn't found. See:

https://wiki.termux.com/wiki/Getting_started

I currently see three downsides with adding the termux folder:

1. Users can just compile it by calling  `./configure --llvm-path=$PREFIX` . This could be added to the readme but still requires manual intervention.
2. This doesn't use the $PREFIX environment variable, because it is not available at compiletime. But the above link suggests that the expanded path is stable
3. Some unit tests don't pass on android, so maybe it shouldn't look like it is officially supported.
dub test output on android: https://gist.github.com/Inkrementator/d16a6fcc9fd630c2275817e0a62095f1