### PR TITLE
libclang 19.1.7

### DIFF
--- a/dstep/translator/Declaration.d
+++ b/dstep/translator/Declaration.d
@@ -10,6 +10,7 @@ import clang.Cursor;
 
 import dstep.translator.Translator;
 import dstep.translator.Output;
+import dstep.translator.Util;
 
 abstract class Declaration
 {
@@ -44,6 +45,6 @@ abstract class Declaration
     @property string spelling ()
     {
         auto name = cursor.spelling;
-        return name.length || parent.isEmpty ? name : translator.context.generateAnonymousName(cursor);
+        return !name.isUnnamed && (name.length || parent.isEmpty) ? name : translator.context.generateAnonymousName(cursor);
     }
 }

--- a/dstep/translator/Enum.d
+++ b/dstep/translator/Enum.d
@@ -19,6 +19,7 @@ import dstep.translator.Declaration;
 import dstep.translator.Output;
 import dstep.translator.Translator;
 import dstep.translator.Type;
+import dstep.translator.Util;
 
 void translateEnumConstantDecl(
     Output output,

--- a/dstep/translator/Util.d
+++ b/dstep/translator/Util.d
@@ -1,0 +1,21 @@
+module dstep.translator.Util;
+
+/** In recent versions of clang (at least 19.1.7), unnamed (anonymous) types will not
+ * set the spelling field to an empty string, but instead to a message like
+ * "enum (unnamed at [declaration_file.h:48]"
+ * "struct (anonymous at [declaration_file.h:48]"
+ * Either unnamed or anonymous is used.
+ * This applies to structs, enums and unions.
+ *
+ * structs and unions additionally have the isAnonymous() helper which doesn't for enums.
+ *
+ * Usage:
+ *      cursor.spelling.isUnnamed()
+ */
+bool isUnnamed(string s){
+    import std.algorithm.searching;
+    return s == "" || 
+            s.canFind("(unnamed at") ||
+            s.canFind("(anonymous at");
+}
+

--- a/tests/unit/issues/Issue8.d
+++ b/tests/unit/issues/Issue8.d
@@ -33,7 +33,7 @@ typedef struct rd_kafka_metadata {
         char       *orig_broker_name; /* Name of originating broker */
 } rd_kafka_metadata_t;
 
-rd_kafka_metadata (rd_kafka_t *rk, int all_topics,
+int rd_kafka_metadata (rd_kafka_t *rk, int all_topics,
                    rd_kafka_topic_t *only_rkt,
                    const struct rd_kafka_metadata **metadatap,
                    int timeout_ms);


### PR DESCRIPTION
Fix anonymous composites in clang 19.1.7

In some new clang versions, the name (cursor.spelling) of anonymous structs,
unions and enums was set to an informative message instead of an empty
string. I.e. "enum (unnamed at [declaration_file.h:48]"

This fixes the errors that happen due to that in a backwards compatible
way, since it still checks for empty spellings.
