### PR TITLE
Fix incorrect spelling collision for struct typedef

### DIFF
--- a/dstep/translator/Context.d
+++ b/dstep/translator/Context.d
@@ -286,6 +286,12 @@ class Context
                 if (options.collisionAction != CollisionAction.ignore)
                 {
                     auto collision = spelling in macroIndex.globalCursors;
+                    if (collision && collision.kind == CXCursorKind.typedefDecl)
+                    {
+                        auto underlying = collision.underlyingCursor();
+                        if (cursor.canonical == underlying.canonical)
+                            collision = null;
+                    }
 
                     while (collision &&
                         collision.canonical != cursor.canonical &&

--- a/tests/functional/nocollision.h
+++ b/tests/functional/nocollision.h
@@ -1,0 +1,3 @@
+#include "structs.h"
+
+typedef D Z;

--- a/tests/unit/Common.d
+++ b/tests/unit/Common.d
@@ -103,6 +103,26 @@ TranslationUnit makeTranslationUnit(string source)
     return TranslationUnit.parseString(index, source, arguments);
 }
 
+TranslationUnit makeTranslationUnitFromFile(
+    string sourceFilename,
+    const string[] commandLineArgs = ["-Wno-missing-declarations"],
+    uint options = CXTranslationUnit_Flags.detailedPreprocessingRecord)
+{
+    import std.algorithm;
+    import std.array;
+
+    Compiler compiler;
+
+    auto index = Index(false, false);
+
+    return TranslationUnit.parse(
+        index,
+        sourceFilename,
+        commandLineArgs ~ compiler.internalFlags,
+        compiler.internalHeaders,
+        options);
+}
+
 CommentIndex makeCommentIndex(string c)
 {
     TranslationUnit translUnit = makeTranslationUnit(c);

--- a/tests/unit/IncludeGraphTests.d
+++ b/tests/unit/IncludeGraphTests.d
@@ -14,29 +14,9 @@ import clang.Util;
 
 import dstep.translator.HeaderIndex;
 
-static TranslationUnit makeTranslationUnit(
-    string sourceFilename,
-    const string[] commandLineArgs = ["-Wno-missing-declarations"],
-    uint options = CXTranslationUnit_Flags.detailedPreprocessingRecord)
-{
-    import std.algorithm;
-    import std.array;
-
-    Compiler compiler;
-
-    auto index = Index(false, false);
-
-    return TranslationUnit.parse(
-        index,
-        sourceFilename,
-        commandLineArgs ~ compiler.internalFlags,
-        compiler.internalHeaders,
-        options);
-}
-
 static IncludeGraph makeIncludeGraph(string sourceFilename)
 {
-    return new IncludeGraph(makeTranslationUnit(sourceFilename));
+    return new IncludeGraph(makeTranslationUnitFromFile(sourceFilename));
 }
 
 unittest
@@ -72,7 +52,7 @@ unittest
 {
     import std.algorithm;
 
-    auto translationUnit = makeTranslationUnit(
+    auto translationUnit = makeTranslationUnitFromFile(
         "tests/functional/clang-c/Index.h",
         ["-Wno-missing-declarations", "-Itests/functional"]);
     auto headerIndex = new HeaderIndex(translationUnit);
@@ -84,7 +64,7 @@ unittest
 
 unittest
 {
-    auto translationUnit = makeTranslationUnit(
+    auto translationUnit = makeTranslationUnitFromFile(
         "tests/functional/graph/self_including_main.h",
         ["-Wno-missing-declarations", "-Itests/functional"]);
 

--- a/tests/unit/UnitTests.d
+++ b/tests/unit/UnitTests.d
@@ -821,6 +821,21 @@ extern __gshared int foo;
 D");
 
     assertTranslates(q"C
+typedef void foo;
+
+struct foo { int x; };
+C", q"D
+extern (C):
+
+alias foo = void;
+
+struct foo_
+{
+    int x;
+}
+D");
+
+    assertTranslates(q"C
 struct foo { };
 
 #define foo 0
@@ -944,6 +959,43 @@ void foo ();
 D", options));
 
     }
+}
+
+// Test abort on spelling collision (another case).
+unittest
+{
+    import std.exception : assertThrown;
+
+    Options options;
+    options.collisionAction = CollisionAction.abort;
+
+    assertThrown!TranslationException(assertTranslates(q"C
+struct foo { int x; } foo;
+C", q"D
+extern (C):
+
+struct foo
+{
+    int x;
+}
+
+extern __gshared foo foo;
+D", options));
+}
+
+// Test that no false collision is detected.
+unittest
+{
+    auto translUnit = makeTranslationUnitFromFile("tests/functional/nocollision.h");
+
+    Options options;
+    options.collisionAction = CollisionAction.abort;
+
+    assertTranslates(q"D
+extern (C):
+
+alias Z = D;
+D", translUnit, options, false);
 }
 
 // Put or don't put a space after the 'function' keyword when


### PR DESCRIPTION
Consider a case where we have 2 files:
`first.h`
```c
typedef struct {
  int a;
} B;
```
And
`second.h`
```c
#include "first.h";

typedef B C;
```

Then currently trying to convert `second.h` we get warning:
```
$ dstep second.h
first.h:2:9: warning: a type renamed to 'B_' due to the collision with the symbol declared in first.h:4:3
```

This is not correct, because `typedef B C` means `C` is alias to `B` and it's not a collision.
This PR fixes this issue.
