### PR TITLE
Fix `-include` header when known modules are used

### DIFF
--- a/dstep/translator/HeaderIndex.d
+++ b/dstep/translator/HeaderIndex.d
@@ -68,6 +68,10 @@ class IncludeGraph
 
                 auto pair = Inclusion(headers_[includedPath], headers_[path]);
                 directInclusions.add(pair);
+            } else if (includedPath != "" && includedPath !in headers_)
+            {
+                reverse_[headers_.length] = includedPath;
+                headers_[includedPath] = headers_.length;
             }
         }
 

--- a/tests/functional/graph/include_known.h
+++ b/tests/functional/graph/include_known.h
@@ -1,0 +1,1 @@
+#include <errno.h>

--- a/tests/unit/IncludeGraphTests.d
+++ b/tests/unit/IncludeGraphTests.d
@@ -90,3 +90,14 @@ unittest
 
     new HeaderIndex(translationUnit);
 }
+
+unittest
+{
+    const string file = "tests/functional/graph/subfile1.h".asAbsNormPath();
+
+    auto translationUnit = makeTranslationUnit(
+        "tests/functional/graph/include_known.h",
+        ["-Wno-missing-declarations", "-Itests/functional", "-include", file]);
+
+    new HeaderIndex(translationUnit);
+}


### PR DESCRIPTION
Currently if you have
`a.h` with:
```
#include <errno.h>
```
And empty `b.h`.
Then `-include` fails:
```
$ dstep -includeb.h a.h
dstep: an unknown error occurred: core.exception.RangeError@dstep/translator/HeaderIndex.d(100): Range violation
----------------
??:? onRangeError [0x55ba460de15a]
??:? _d_arraybounds [0x55ba460c4d15]
dstep/translator/HeaderIndex.d:100 bool dstep.translator.HeaderIndex.IncludeGraph.isReachableBy(immutable(char)[], immutable(char)[]) [0x55ba4606bf29]
dstep/translator/HeaderIndex.d:382 immutable(char)[][immutable(char)[]] dstep.translator.HeaderIndex.HeaderIndex.resolveKnownModules!(std.algorithm.iteration.FilterResult!(dstep.translator.HeaderIndex.HeaderIndex.__ctor(clang.TranslationUnit.TranslationUnit, const(immutable(char)[][immutable(char)[]])).__lambda_L308_C9, clang.Cursor.Cursor[]).FilterResult).resolveKnownModules(std.algorithm.iteration.FilterResult!(dstep.translator.HeaderIndex.HeaderIndex.__ctor(clang.TranslationUnit.TranslationUnit, const(immutable(char)[][immutable(char)[]])).__lambda_L308_C9, clang.Cursor.Cursor[]).FilterResult, dstep.translator.HeaderIndex.HeaderIndex.KnownModule[]) [0x55ba4606f0b7]
dstep/translator/HeaderIndex.d:323 dstep.translator.HeaderIndex.HeaderIndex dstep.translator.HeaderIndex.HeaderIndex.__ctor!(std.algorithm.iteration.FilterResult!(dstep.translator.HeaderIndex.HeaderIndex.__ctor(clang.TranslationUnit.TranslationUnit, const(immutable(char)[][immutable(char)[]])).__lambda_L308_C9, clang.Cursor.Cursor[]).FilterResult).__ctor(std.algorithm.iteration.FilterResult!(dstep.translator.HeaderIndex.HeaderIndex.__ctor(clang.TranslationUnit.TranslationUnit, const(immutable(char)[][immutable(char)[]])).__lambda_L308_C9, clang.Cursor.Cursor[]).FilterResult, const(immutable(char)[][immutable(char)[]])) [0x55ba4606ee48]
dstep/translator/HeaderIndex.d:316 dstep.translator.HeaderIndex.HeaderIndex dstep.translator.HeaderIndex.HeaderIndex.__ctor(clang.TranslationUnit.TranslationUnit, const(immutable(char)[][immutable(char)[]])) [0x55ba4606da89]
dstep/translator/HeaderIndex.d:293 dstep.translator.HeaderIndex.HeaderIndex dstep.translator.HeaderIndex.HeaderIndex.__ctor(clang.TranslationUnit.TranslationUnit) [0x55ba4606d95d]
dstep/translator/Context.d:158 dstep.translator.HeaderIndex.HeaderIndex dstep.translator.Context.Context.headerIndex() [0x55ba4606724a]
dstep/translator/Context.d:51 dstep.translator.Context.Context dstep.translator.Context.Context.__ctor(clang.TranslationUnit.TranslationUnit, dstep.translator.Options.Options, dstep.translator.Translator.Translator) [0x55ba46066c67]
dstep/translator/Translator.d:70 dstep.translator.Translator.Translator dstep.translator.Translator.Translator.__ctor(clang.TranslationUnit.TranslationUnit, dstep.translator.Options.Options) [0x55ba460ab587]
dstep/driver/Application.d:65 void dstep.driver.Application.Application.run() [0x55ba46052147]
dstep/driver/CommandLine.d:181 int dstep.driver.CommandLine.run(immutable(char)[][]) [0x55ba46062a61]
dstep/main.d:18 _Dmain [0x55ba46065977]
core.exception.RangeError@dstep/translator/HeaderIndex.d(100): Range violation
----------------
??:? onRangeError [0x55ba460de15a]
??:? _d_arraybounds [0x55ba460c4d15]
dstep/translator/HeaderIndex.d:100 bool dstep.translator.HeaderIndex.IncludeGraph.isReachableBy(immutable(char)[], immutable(char)[]) [0x55ba4606bf29]
dstep/translator/HeaderIndex.d:382 immutable(char)[][immutable(char)[]] dstep.translator.HeaderIndex.HeaderIndex.resolveKnownModules!(std.algorithm.iteration.FilterResult!(dstep.translator.HeaderIndex.HeaderIndex.__ctor(clang.TranslationUnit.TranslationUnit, const(immutable(char)[][immutable(char)[]])).__lambda_L308_C9, clang.Cursor.Cursor[]).FilterResult).resolveKnownModules(std.algorithm.iteration.FilterResult!(dstep.translator.HeaderIndex.HeaderIndex.__ctor(clang.TranslationUnit.TranslationUnit, const(immutable(char)[][immutable(char)[]])).__lambda_L308_C9, clang.Cursor.Cursor[]).FilterResult, dstep.translator.HeaderIndex.HeaderIndex.KnownModule[]) [0x55ba4606f0b7]
dstep/translator/HeaderIndex.d:323 dstep.translator.HeaderIndex.HeaderIndex dstep.translator.HeaderIndex.HeaderIndex.__ctor!(std.algorithm.iteration.FilterResult!(dstep.translator.HeaderIndex.HeaderIndex.__ctor(clang.TranslationUnit.TranslationUnit, const(immutable(char)[][immutable(char)[]])).__lambda_L308_C9, clang.Cursor.Cursor[]).FilterResult).__ctor(std.algorithm.iteration.FilterResult!(dstep.translator.HeaderIndex.HeaderIndex.__ctor(clang.TranslationUnit.TranslationUnit, const(immutable(char)[][immutable(char)[]])).__lambda_L308_C9, clang.Cursor.Cursor[]).FilterResult, const(immutable(char)[][immutable(char)[]])) [0x55ba4606ee48]
dstep/translator/HeaderIndex.d:316 dstep.translator.HeaderIndex.HeaderIndex dstep.translator.HeaderIndex.HeaderIndex.__ctor(clang.TranslationUnit.TranslationUnit, const(immutable(char)[][immutable(char)[]])) [0x55ba4606da89]
dstep/translator/HeaderIndex.d:293 dstep.translator.HeaderIndex.HeaderIndex dstep.translator.HeaderIndex.HeaderIndex.__ctor(clang.TranslationUnit.TranslationUnit) [0x55ba4606d95d]
dstep/translator/Context.d:158 dstep.translator.HeaderIndex.HeaderIndex dstep.translator.Context.Context.headerIndex() [0x55ba4606724a]
dstep/translator/Context.d:51 dstep.translator.Context.Context dstep.translator.Context.Context.__ctor(clang.TranslationUnit.TranslationUnit, dstep.translator.Options.Options, dstep.translator.Translator.Translator) [0x55ba46066c67]
dstep/translator/Translator.d:70 dstep.translator.Translator.Translator dstep.translator.Translator.Translator.__ctor(clang.TranslationUnit.TranslationUnit, dstep.translator.Options.Options) [0x55ba460ab587]
dstep/driver/Application.d:65 void dstep.driver.Application.Application.run() [0x55ba46052147]
dstep/driver/CommandLine.d:181 int dstep.driver.CommandLine.run(immutable(char)[][]) [0x55ba46062a61]
dstep/main.d:18 _Dmain [0x55ba46065977]
```

This PR fixes it so that it works.
