### PR TITLE
Fix `extern (C)` header case

### DIFF
--- a/dstep/translator/IncludeHandler.d
+++ b/dstep/translator/IncludeHandler.d
@@ -197,8 +197,6 @@ class IncludeHandler
 
         if (options.keepUntranslatable)
             importsBlock(output, unhandled.keys);
-
-        output.finalize();
     }
 
     bool resolveDependency(in Cursor cursor)

--- a/dstep/translator/Output.d
+++ b/dstep/translator/Output.d
@@ -850,8 +850,8 @@ D"[0 .. $ - 1]);
         if (commentIndex && commentIndex.isHeaderCommentPresent)
         {
             auto location = commentIndex.queryHeaderCommentExtent.end;
-            headerEndOffset = location.offset + 2;
             flushLocation(location, false);
+            headerEndOffset = cast(uint) buffer.data.length + 2;
             return true;
         }
         else

--- a/dstep/translator/Translator.d
+++ b/dstep/translator/Translator.d
@@ -78,6 +78,7 @@ class Translator
     Output translateCursors()
     {
         Output result = new Output(context.commentIndex);
+        Output content;
         typedMacroDefinitions = inferMacroSignatures(context);
 
         bool first = true;
@@ -91,20 +92,32 @@ class Translator
                     if (result.flushHeaderComment())
                         result.separator();
 
-                    externDeclaration(result);
+                    content = new Output(result);
+                    externDeclaration(content);
                     first = false;
                 }
 
-                translateInGlobalScope(result, cursor, parent);
+                translateInGlobalScope(content, cursor, parent);
             }
         }
 
+        if (first)
+        {
+            if (result.flushHeaderComment())
+                result.separator();
+
+            content = new Output(result);
+        }
+
         if (context.commentIndex)
-            result.flushLocation(context.commentIndex.queryLastLocation());
+            content.flushLocation(context.commentIndex.queryLastLocation());
 
         foreach (value; deferredDeclarations.values)
-            result.singleLine(value);
+            content.singleLine(value);
 
+        moduleDeclaration(result);
+        context.includeHandler.toImports(result);
+        result.output(content);
         result.finalize();
 
         return result;
@@ -112,15 +125,7 @@ class Translator
 
     string translateToString()
     {
-        import std.algorithm.mutation : strip;
-
-        Output main = translateCursors();
-        Output head = new Output();
-
-        moduleDeclaration(head);
-        context.includeHandler.toImports(head);
-
-        return main.header ~ head.data ~ main.content;
+        return translateCursors().data;
     }
 
     void translateInGlobalScope(

--- a/tests/unit/CommentUnitTests.d
+++ b/tests/unit/CommentUnitTests.d
@@ -33,6 +33,31 @@ q"D
 D", options, false);
 }
 
+unittest
+{
+    Options options;
+    options.packageName = "a";
+    options.outputFile = "a.h";
+    options.globalImports = ["b"];
+
+    assertTranslates(
+"/**\n * comment with trailing whitespace  \n *   \n**/\n\n#pragma once\n\n#define A 1\n",
+q"D
+/**
+ * comment with trailing whitespace
+ *
+**/
+
+module a.a;
+
+import b;
+
+extern (C):
+
+enum A = 1;
+D", options, true);
+}
+
 // Test single comment.
 unittest
 {

--- a/tests/unit/CommentUnitTests.d
+++ b/tests/unit/CommentUnitTests.d
@@ -18,6 +18,23 @@ q"D
 D", true);
 }
 
+unittest
+{
+    Options options;
+    options.packageName = "a";
+    options.outputFile = "b.h";
+
+    assertTranslates(
+q"C
+/* Header comment. */
+C",
+q"D
+/* Header comment. */
+
+module a.b;
+D", options, true);
+}
+
 // Test disabled comments.
 unittest
 {


### PR DESCRIPTION
Currently if you have `a.h` like:
```c
/**
 * comment
 *
**/

#pragma once

#define A 1
```
And you run `dstep --package a --global-import b a.h`
Then result will be broken code (note split `extern`):
```d
/**
 * comment
 *
**/

extmodule a.a;

import b;

ern (C):

enum A = 1;
```

This PR fixes that so it will be correct code:
```d
/**
 * comment
 *
**/

module a.a;

import b;



extern (C):

enum A = 1;
```
