### PR TITLE
Comment out compiler builtins

### DIFF
--- a/dstep/translator/MacroDefinition.d
+++ b/dstep/translator/MacroDefinition.d
@@ -522,6 +522,7 @@ bool translateFunctAlias(
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : map;
+    import std.algorithm.searching : startsWith;
 
     CallExpr* expr = definition.expr.peek!CallExpr;
     auto expressionContext = ExpressionContext.make(context);
@@ -554,11 +555,17 @@ bool translateFunctAlias(
                 .map!(a => a.translate(expressionContext))))
         {
             version (D1)
-                enum fmt = "alias %2$s %1$s;";
+                string fmt = "alias %2$s %1$s;";
             else
-                enum fmt = "alias %1$s = %2$s;";
+                string fmt = "alias %1$s = %2$s;";
 
-            output.singleLine(fmt, definition.spelling, ident.spelling);
+            // Handle compiler builtins (eg. __builtin_unreachable)
+            string value = ident.spelling;
+            if (value.startsWith("__builtin_") || value == "_Alignof")
+            {
+                fmt = "// FIXME: " ~ fmt;
+            }
+            output.singleLine(fmt, definition.spelling, value);
             return true;
         }
     }
@@ -592,6 +599,8 @@ void translateMacroDefinitionAliasOrConst(
     Context context,
     TypedMacroDefinition definition)
 {
+    import std.algorithm.searching : startsWith, canFind;
+
     auto expressionContext = ExpressionContext.make(context);
 
     string formatString;
@@ -612,10 +621,19 @@ void translateMacroDefinitionAliasOrConst(
             formatString = "enum %s = %s;";
     }
 
+    string value = debraced.translate(expressionContext);
+    if (["const", "static", "volatile", "_Static_assert"].canFind(value) ||
+        // Handle compiler builtins
+        value.startsWith("__builtin_") ||
+        value.startsWith("__attribute__"))
+    {
+        formatString = "// FIXME: " ~ formatString;
+    }
+
     output.singleLine(
         formatString,
         definition.definition.spelling,
-        debraced.translate(expressionContext));
+        value);
 
     expressionContext.elevateImports();
 }

--- a/tests/unit/MacroTranslTests.d
+++ b/tests/unit/MacroTranslTests.d
@@ -841,3 +841,25 @@ extern (D) auto fun(T)(auto ref T a)
 }
 D");
 }
+
+// Comment out compiler builtins and language keywords.
+unittest
+{
+    assertTMD(q"C
+#define va_copy __builtin_va_copy
+C", q"D
+// FIXME: enum va_copy = __builtin_va_copy;
+D");
+
+    assertTMD(q"C
+#define fake _builtin_fake
+C", q"D
+enum fake = _builtin_fake;
+D");
+
+    assertTMD(q"C
+#define foo(x) __builtin_foo(x)
+C", q"D
+// FIXME: alias foo = __builtin_foo;
+D");
+}


### PR DESCRIPTION
Consider C header like:
```c
#define va_copy __builtin_va_copy
#define ALIGNOF(TYPE)  _Alignof (TYPE)
#define __unused  __attribute__((__unused__))
#define __noreturn  __attribute__((__noreturn__))
#define STATIC_ASSERT  _Static_assert
#define CONST  const
#define STATIC  static
#define __volatile  volatile
```

Currently `dsep` would produce:
```d
enum va_copy = __builtin_va_copy;
```
Which fails to compile:
```
Error: undefined identifier `__builtin_va_copy`
enum va_copy = __builtin_va_copy;
```

When this PR is applied together with #303
Then result will be:
```d
// FIXME: enum va_copy = __builtin_va_copy;
// FIXME: alias ALIGNOF = _Alignof;
// FIXME: enum __unused = __attribute__(__unused__);
// FIXME: enum __noreturn = __attribute__(__noreturn__);
// FIXME: enum STATIC_ASSERT = _Static_assert;
// FIXME: enum CONST = const;
// FIXME: enum STATIC = static;
```
