### PR TITLE
Fix wide strings with `L` prefix

### DIFF
--- a/dstep/translator/MacroDefinition.d
+++ b/dstep/translator/MacroDefinition.d
@@ -105,6 +105,9 @@ string translate(Literal literal, ExpressionContext context)
         auto suffix = literal.spelling[integer.length .. $];
         auto core = uinteger[0 .. $ - 1].stripLeft('0') ~ uinteger[$ - 1];
         return "octal!" ~ core ~ suffix;
+    } else if (literal.spelling.length >= 3 && literal.spelling[0..2] == "L\"")
+    {
+        return literal.spelling[1..$] ~ "w";
     }
 
     return literal.spelling;

--- a/tests/unit/MacroTranslTests.d
+++ b/tests/unit/MacroTranslTests.d
@@ -841,3 +841,19 @@ extern (D) auto fun(T)(auto ref T a)
 }
 D");
 }
+
+// Translate wide string literals with L prefix.
+unittest
+{
+    assertTMD(q"C
+#define H L"hello world"
+C", q"D
+enum H = "hello world"w;
+D");
+
+    assertTMD(q"C
+#define E L""
+C", q"D
+enum E = ""w;
+D");
+}


### PR DESCRIPTION
If you have C code that uses wide strings like
```c
#define H L"hello world"
```
Then currently `dstep` doesn't convert it causing wrong D code to be created.

This PR implements converting such code to valid D.

