### PR TITLE
Fix <unimplemented> for size_t return type on builtins

### DIFF
--- a/dstep/translator/Type.d
+++ b/dstep/translator/Type.d
@@ -300,8 +300,11 @@ do
     if (declaration.isValid)
         return translateType(context, declaration, rewriteIdToObjcObject);
     else
+    {
+        type = type.canonical.isValid ? type.canonical : type;
         return translateType(context, type.kind, rewriteIdToObjcObject)
             .makeSourceNode();
+    }
 }
 
 string translateComplex (Type type)

--- a/tests/functional/Tests.d
+++ b/tests/functional/Tests.d
@@ -227,6 +227,14 @@ unittest
     );
 }
 
+unittest
+{
+    assertRunsDStepCFile(
+        "tests/functional/size_t_redeclared.d",
+        "tests/functional/size_t_redeclared.h"
+    );
+}
+
 // DStep should exit with non-zero status when an input file doesn't exist.
 unittest
 {

--- a/tests/functional/size_t_redeclared.d
+++ b/tests/functional/size_t_redeclared.d
@@ -1,0 +1,6 @@
+import core.stdc.config;
+
+extern (C):
+
+c_ulong strlen (const(char)* __s);
+c_ulong fread ();

--- a/tests/functional/size_t_redeclared.h
+++ b/tests/functional/size_t_redeclared.h
@@ -1,0 +1,6 @@
+
+#include  <stdio.h>
+
+size_t strlen(const char *__s);
+size_t fread();
+


### PR DESCRIPTION
Currently if you have code like this:
```c
#include  <stdio.h>

size_t strlen(const char *__s);
size_t fread();
```

It's translated to:
```d
extern (C):

<unimplemented> strlen (const(char)* __s);
<unimplemented> fread ();
```
Which obviously is invalid code.
This PR fixes this to create correct D code.

Note that this issue happens only with compiler's builtin functions that return `size_t` because clang merges it to internal unexposed type.

